### PR TITLE
Fixes api not filtering requests/all query when filtering

### DIFF
--- a/seasoned_api/src/plex/requestRepository.js
+++ b/seasoned_api/src/plex/requestRepository.js
@@ -8,21 +8,17 @@ const plexRepository = new PlexRepository();
 const cache = new Cache();
 const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
 
-const MailTemplate = require('src/plex/mailTemplate');
-const nodemailer = require('nodemailer');
-
-
 class RequestRepository {
-   constructor(cache, database) {
+   constructor(database) {
       this.database = database || establishedDatabase;
       this.queries = {
          insertRequest: `INSERT INTO requests(id,title,year,poster_path,background_path,requested_by,ip,user_agent,type)
           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
          fetchRequestedItems: 'SELECT * FROM requests ORDER BY date DESC',
-         fetchRequestedItemsByStatus: 'SELECT * FROM requests WHERE status IS ? AND type LIKE ?',
+         fetchRequestedItemsByStatus: 'SELECT * FROM requests WHERE status IS ? AND type LIKE ? ORDER BY date DESC',
          updateRequestedById: 'UPDATE requests SET status = ? WHERE id is ? AND type is ?',
          checkIfIdRequested: 'SELECT * FROM requests WHERE id IS ? AND type IS ?',
-         userRequests: 'SELECT * FROM requests WHERE requested_by IS ?'
+         userRequests: 'SELECT * FROM requests WHERE requested_by IS ?',
       };
       this.cacheTags = {
          search: 'se',
@@ -51,10 +47,7 @@ class RequestRepository {
          .then(() => this.database.get(this.queries.checkIfIdRequested, [tmdbMovie.id, tmdbMovie.type]))
          .then((result, error) => {
             if (error) { throw new Error(error); }
-            let already_requested = false;
-            if (result) { already_requested = true; }
-
-            tmdbMovie.requested = already_requested;
+            tmdbMovie.requested = result ? true : false;
             return tmdbMovie;
          });
    }
@@ -65,33 +58,35 @@ class RequestRepository {
    * @returns {Promise} If nothing has gone wrong.
    */
    sendRequest(identifier, type, ip, user_agent, user) {
-   	return Promise.resolve()
-   	.then(() => tmdb.lookup(identifier, type))
-      .then((movie) => {
-      	const username = user == undefined ? undefined : user.username;
-         // Add request to database
-         return this.database.run(this.queries.insertRequest, [movie.id, movie.title, movie.year, movie.poster_path, movie.background_path, username, ip, user_agent, movie.type]);
-      });
+      return Promise.resolve()
+         .then(() => tmdb.lookup(identifier, type))
+         .then((movie) => {
+            const username = user === undefined ? undefined : user.username;
+            // Add request to database
+            return this.database.run(this.queries.insertRequest, [movie.id, movie.title, movie.year, movie.poster_path, movie.background_path, username, ip, user_agent, movie.type]);
+         });
    }
 
    fetchRequested(status, type = '%') {
-   	return Promise.resolve()
-   	.then(() => {
-	      if (status === 'requested' || status === 'downloading' || status === 'downloaded')
-	         return this.database.all(this.queries.fetchRequestedItemsByStatus, [status, type]);
-	      else
-	         return this.database.all(this.queries.fetchRequestedItems);
-   	})
+      return Promise.resolve()
+         .then(() => {
+            if (status === 'requested' || status === 'downloading' || status === 'downloaded') {
+               return this.database.all(this.queries.fetchRequestedItemsByStatus, [status, type]);
+            }
+            return this.database.all(this.queries.fetchRequestedItems);
+         });
    }
 
    userRequests(user) {
-   	return Promise.resolve()
+      return Promise.resolve()
          .then(() => this.database.all(this.queries.userRequests, user.username))
          .catch((error) => {
-            if (String(error).includes('no such column')) { throw new Error('Username not found'); }
-            else { throw new Error('Unable to fetch your requests')}
+            if (String(error).includes('no such column')) {
+               throw new Error('Username not found');
+            }
+            throw new Error('Unable to fetch your requests');
          })
-         .then((result) => { return result })
+         .then((result) => { return result; });
    }
 
    updateRequestedById(id, type, status) {


### PR DESCRIPTION
Issue: 
api/v1/plex/requests/all returns all elements sorted DESC
api/v1/plex/requests/all?status=requested returns only requested elements BUT sorted ASC by default.

Fix:
When filtering the request on status the sql query for the db is now sorts DESC.

Other:
Corrected some linting issues.