### PR TITLE
Added coverage stats with nyc and coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ node_js: '8.7.0'
 git:
    submodules: true
 script:
-   yarn test
+   - yarn test
+   - yarn doc
 before_install:
    - cd seasoned_api
 before_script: yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ git:
    submodules: true
 script:
    - yarn test
-   - yarn cov 
+   - yarn coverage 
 before_install:
    - cd seasoned_api
 before_script: yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ git:
    submodules: true
 script:
    - yarn test
-   - yarn doc
+   - yarn cov 
 before_install:
    - cd seasoned_api
 before_script: yarn

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # 🌶 seasonedShows
 [![Build Status](https://travis-ci.org/KevinMidboe/seasonedShows.svg?branch=master)](https://travis-ci.org/KevinMidboe/seasonedShows)
+[![Coverage Status](https://coveralls.io/repos/github/KevinMidboe/seasonedShows/badge.svg?branch=coverage)](https://coveralls.io/github/KevinMidboe/seasonedShows?branch=coverage)
 [![Known Vulnerabilities](https://snyk.io/test/github/KevinMidboe/seasonedShows/badge.svg?targetFile=seasoned_api/package.json)](https://snyk.io/test/github/KevinMidboe/seasonedShows?targetFile=seasoned_api/package.json)
 [![DUB](https://img.shields.io/dub/l/vibe-d.svg)]()
 

--- a/seasoned_api/package.json
+++ b/seasoned_api/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "cross-env SEASONED_CONFIG=conf/development.json NODE_PATH=. node src/webserver/server.js",
     "test": "cross-env SEASONED_CONFIG=conf/test.json NODE_PATH=. mocha --recursive test",
+    "cov": "cross-env SEASONED_CONFIG=conf/test.json NODE_PATH=. nyc mocha --recursive test && nyc report --reporter=text-lcov | coveralls",
     "coverage": "cross-env SEASONED_CONFIG=conf/test.json NODE_PATH=. istanbul cover -x script/autogenerate-documentation.js --include-all-sources --dir test/.coverage node_modules/mocha/bin/_mocha --recursive test/**/* -- --report lcovonly && cat test/.coverage/lcov.info | coveralls && rm -rf test/.coverage",
     "lint": "./node_modules/.bin/eslint src/"
   },
@@ -28,12 +29,14 @@
     "sqlite3": "4.0.0"
   },
   "devDependencies": {
+    "coveralls": "^3.0.0",
     "eslint": "^4.9.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.8.0",
     "istanbul": "^0.4.5",
     "mocha": "^5.0.4",
     "mocha-lcov-reporter": "^1.3.0",
+    "nyc": "^11.6.0",
     "raven": "^2.4.2",
     "supertest": "^3.0.0",
     "supertest-as-promised": "^4.0.1"

--- a/seasoned_api/package.json
+++ b/seasoned_api/package.json
@@ -9,13 +9,11 @@
   "scripts": {
     "start": "cross-env SEASONED_CONFIG=conf/development.json NODE_PATH=. node src/webserver/server.js",
     "test": "cross-env SEASONED_CONFIG=conf/test.json NODE_PATH=. mocha --recursive test",
-    "cov": "cross-env SEASONED_CONFIG=conf/test.json NODE_PATH=. nyc mocha --recursive test && nyc report --reporter=text-lcov | coveralls",
-    "coverage": "cross-env SEASONED_CONFIG=conf/test.json NODE_PATH=. istanbul cover -x script/autogenerate-documentation.js --include-all-sources --dir test/.coverage node_modules/mocha/bin/_mocha --recursive test/**/* -- --report lcovonly && cat test/.coverage/lcov.info | coveralls && rm -rf test/.coverage",
+    "coverage": "cross-env SEASONED_CONFIG=conf/test.json NODE_PATH=. nyc mocha --recursive test && nyc report --reporter=text-lcov | coveralls",
     "lint": "./node_modules/.bin/eslint src/"
   },
   "dependencies": {
     "bcrypt-nodejs": "^0.0.3",
-    "blanket": "^1.2.3",
     "body-parser": "~1.18.2",
     "cross-env": "~5.1.4",
     "express": "~4.16.0",


### PR DESCRIPTION
Added nyc for mocha test coverage. 
Pass the results of nyc and mocha-lcov-reporter to coveralls. 