### PR TITLE
Fixed issue matching list of plex object to tmdb.

### DIFF
--- a/seasoned_api/src/plex/plex.js
+++ b/seasoned_api/src/plex/plex.js
@@ -10,6 +10,19 @@ const { Movie, Show, Person } = require('src/tmdb/types');
 // TODO? import class definitions to compare types ?
 // what would typescript do?
 
+const matchingTitleOrName = (plex, tmdb) => {
+  if (plex['title'] !== undefined && tmdb['title'] !== undefined)
+      return sanitize(plex.title) === sanitize(tmdb.title)
+
+  return false
+}
+
+const matchingYear = (plex, tmdb) => {
+  return plex.year === tmdb.year
+}
+
+const sanitize = (string) => string.toLowerCase()
+
 class Plex {
   constructor(ip, port=32400) {
     this.plexIP = ip
@@ -20,12 +33,22 @@ class Plex {
     if (plex === undefined || tmdb === undefined)
       return false
 
-    const sanitize = (string) => string.toLowerCase()
+    let titleMatches;
+    let yearMatches;
 
-    const matchTitle = sanitize(plex.title) === sanitize(tmdb.title)
-    const matchYear = plex.year === tmdb.year
+    if (plex instanceof Array) {
+      console.log('Plex object to compare is a list.')
+      const plexList = plex
+      console.log('List of plex objects:', plexList)
 
-    return matchTitle && matchYear
+      titleMatches = plexList.map(plexItem => matchingTitleOrName(plexItem, tmdb))
+      yearMatches = plexList.map(plexItem => matchingYear(plexItem, tmdb))
+    } else {
+      titleMatches = matchingTitleOrName(plex, tmdb)
+      yearMatches = matchingYear(plex, tmdb)
+    }
+
+    return titleMatches && yearMatches
   }
 
   existsInPlex(tmdbMovie) {


### PR DESCRIPTION
We have a Plex function that allows us to input a tmdb object and a plex
search result too see if the tmdb object has anything similar when
searching in plex.
Fixed an issue where plex returned a list of items. This list is now
mapped over each list element.