### PR TITLE
Feat/redis cache

### DIFF
--- a/seasoned_api/package.json
+++ b/seasoned_api/package.json
@@ -29,6 +29,7 @@
     "node-fetch": "^2.6.0",
     "python-shell": "^0.5.0",
     "raven": "^2.4.2",
+    "redis": "^3.0.2",
     "request": "^2.87.0",
     "request-promise": "^4.2",
     "sqlite3": "^4.0.0"

--- a/seasoned_api/src/cache/redis.js
+++ b/seasoned_api/src/cache/redis.js
@@ -1,0 +1,46 @@
+const redis = require("redis")
+const client = redis.createClient()
+
+class Cache {
+  /**
+   * Retrieve an unexpired cache entry by key.
+   * @param {String} key of the cache entry
+   * @returns {Promise}
+   */
+  get(key) {
+    return new Promise((resolve, reject) => {
+      client.get(key, (error, reply) => {
+        if (reply == null) {
+          reject()
+        }
+
+        resolve(JSON.parse(reply))
+      })
+    })
+  }
+
+   /**
+   * Insert cache entry with key and value.
+   * @param {String} key of the cache entry
+   * @param {String} value of the cache entry
+   * @param {Number} timeToLive the number of seconds before entry expires
+   * @returns {Object}
+   */
+  set(key, value, timeToLive = 10800) {
+    const json = JSON.stringify(value);
+    client.set(key, json, (error, reply) => {
+      if (reply == 'OK') {
+
+        // successfully set value with key, now set TTL for key
+        client.expire(key, timeToLive, (e) => {
+          if (e) 
+            console.error('Unexpected error while setting expiration for key:', key, '. Error:', error)
+        })
+      }
+    })
+
+    return value
+  }
+}
+
+module.exports = Cache;

--- a/seasoned_api/src/cache/redis.js
+++ b/seasoned_api/src/cache/redis.js
@@ -11,7 +11,7 @@ class Cache {
     return new Promise((resolve, reject) => {
       client.get(key, (error, reply) => {
         if (reply == null) {
-          reject()
+          return reject()
         }
 
         resolve(JSON.parse(reply))
@@ -27,6 +27,9 @@ class Cache {
    * @returns {Object}
    */
   set(key, value, timeToLive = 10800) {
+    if (value == null || key == null)
+      return null
+
     const json = JSON.stringify(value);
     client.set(key, json, (error, reply) => {
       if (reply == 'OK') {

--- a/seasoned_api/src/database/schemas/setup.sql
+++ b/seasoned_api/src/database/schemas/setup.sql
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS search_history (
 );
 
 CREATE TABLE IF NOT EXISTS requests(
-    id TEXT,
+    id NUMBER,
     title TEXT,
     year NUMBER,
     poster_path TEXT DEFAULT NULL,

--- a/seasoned_api/src/plex/plex.js
+++ b/seasoned_api/src/plex/plex.js
@@ -93,8 +93,8 @@ class Plex {
     return match 
   }
 
-  existsInPlex(tmdb) {
-    const plexMatch = this.findPlexItemByTitleAndYear(tmdb.title, tmdb.year)
+  async existsInPlex(tmdb) {
+    const plexMatch = await this.findPlexItemByTitleAndYear(tmdb.title, tmdb.year)
     return plexMatch ? true : false
   }
 

--- a/seasoned_api/src/plex/plex.js
+++ b/seasoned_api/src/plex/plex.js
@@ -67,6 +67,7 @@ class Plex {
   }
 
   search(query) {
+    query = encodeURIComponent(query)
     const url = `http://${this.plexIP}:${this.plexPort}/hubs/search?query=${query}`
     const options = {
       timeout: 2000,

--- a/seasoned_api/src/plex/plex.js
+++ b/seasoned_api/src/plex/plex.js
@@ -3,8 +3,10 @@ const convertPlexToMovie = require('src/plex/convertPlexToMovie')
 const convertPlexToShow = require('src/plex/convertPlexToShow')
 const convertPlexToEpisode = require('src/plex/convertPlexToEpisode')
 
+const { Movie, Show, Person } = require('src/tmdb/types')
 
-const { Movie, Show, Person } = require('src/tmdb/types');
+const RedisCache = require('src/cache/redis')
+const redisCache = new RedisCache()
 
 // const { Movie, } 
 // TODO? import class definitions to compare types ?
@@ -24,9 +26,14 @@ const matchingYear = (plex, tmdb) => {
 const sanitize = (string) => string.toLowerCase()
 
 class Plex {
-  constructor(ip, port=32400) {
+  constructor(ip, port=32400, cache=null) {
     this.plexIP = ip
     this.plexPort = port
+
+    this.cache = cache || redisCache;
+    this.cacheTags = {
+      search: 's'
+    }
   }
 
   matchTmdbAndPlexMedia(plex, tmdb) {
@@ -37,12 +44,12 @@ class Plex {
     let yearMatches;
 
     if (plex instanceof Array) {
-      console.log('Plex object to compare is a list.')
       const plexList = plex
-      console.log('List of plex objects:', plexList)
 
       titleMatches = plexList.map(plexItem => matchingTitleOrName(plexItem, tmdb))
       yearMatches = plexList.map(plexItem => matchingYear(plexItem, tmdb))
+      titleMatches = titleMatches.includes(true)
+      yearMatches = yearMatches.includes(true)
     } else {
       titleMatches = matchingTitleOrName(plex, tmdb)
       yearMatches = matchingYear(plex, tmdb)

--- a/seasoned_api/src/plex/plex.js
+++ b/seasoned_api/src/plex/plex.js
@@ -87,8 +87,8 @@ class Plex {
   }
 
   mapResults(response) {
-    if (response === undefined || response.MediaContainer === undefined) {
-      console.log('response was not valid to map', response)
+    if (response == null || response.MediaContainer == null || response.MediaContainer.Hub == null) {
+      console.log('No results to map in:', response)
       return []
     }
 

--- a/seasoned_api/src/plex/requestRepository.js
+++ b/seasoned_api/src/plex/requestRepository.js
@@ -1,12 +1,10 @@
 const PlexRepository = require('src/plex/plexRepository');
-const Cache = require('src/tmdb/cache');
 const configuration = require('src/config/configuration').getInstance();
 const TMDB = require('src/tmdb/tmdb');
 const establishedDatabase = require('src/database/database');
 
 const plexRepository = new PlexRepository(configuration.get('plex', 'ip'));
-const cache = new Cache();
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'));
 
 class RequestRepository {
    constructor(database) {

--- a/seasoned_api/src/request/request.js
+++ b/seasoned_api/src/request/request.js
@@ -1,9 +1,7 @@
 const assert = require('assert')
 const configuration = require('src/config/configuration').getInstance();
-const Cache = require('src/tmdb/cache');
 const TMDB = require('src/tmdb/tmdb');
-const cache = new Cache();
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'));
 const establishedDatabase = require('src/database/database');
 const utils = require('./utils');
 

--- a/seasoned_api/src/tmdb/tmdb.js
+++ b/seasoned_api/src/tmdb/tmdb.js
@@ -205,7 +205,7 @@ class TMDB {
     const cacheKey = `tmdb/${this.cacheTags[listname]}:${page}`;
 
     return this.getFromCacheOrFetchFromTmdb(cacheKey, listname, query)
-      .then(response => this.cache.set(cacheKey, response, 10800))
+      .then(response => this.cache.set(cacheKey, response, this.defaultTTL))
       .then(response => this.mapResults(response, 'movie'))
   }
 
@@ -214,7 +214,7 @@ class TMDB {
     const cacheKey = `tmdb/${this.cacheTags[listname]}:${page}`;
 
      return this.getFromCacheOrFetchFromTmdb(cacheKey, listName, query)
-      .then(response => this.cache.set(cacheKey, response, 10800))
+      .then(response => this.cache.set(cacheKey, response, this.defaultTTL))
       .then(response => this.mapResults(response, 'show'))
   }
 

--- a/seasoned_api/src/tmdb/tmdb.js
+++ b/seasoned_api/src/tmdb/tmdb.js
@@ -27,9 +27,10 @@ const tmdbErrorResponse = (error, typeString=undefined) => {
 }
 
 class TMDB {
-  constructor(cache, apiKey, tmdbLibrary) {
-    this.cache = cache || redisCache;
+  constructor(apiKey, cache, tmdbLibrary) {
     this.tmdbLibrary = tmdbLibrary || moviedb(apiKey);
+
+    this.cache = cache || redisCache;
     this.cacheTags = {
       multiSearch: 'mus', 
       movieSearch: 'mos', 

--- a/seasoned_api/src/webserver/app.js
+++ b/seasoned_api/src/webserver/app.js
@@ -113,6 +113,8 @@ router.get('/v1/plex/request/:mediaId', require('./controllers/plex/readRequest.
 router.post('/v1/plex/request/:mediaId', require('./controllers/plex/submitRequest.js'));
 router.post('/v1/plex/hook', require('./controllers/plex/hookDump.js'));
 
+router.get('/v1/plex/watch-link', mustBeAuthenticated, require('./controllers/plex/watchDirectLink.js'));
+
 /**
  * Requests
  */

--- a/seasoned_api/src/webserver/controllers/list/listController.js
+++ b/seasoned_api/src/webserver/controllers/list/listController.js
@@ -1,8 +1,6 @@
 const configuration = require('src/config/configuration').getInstance();
-const Cache = require('src/tmdb/cache');
 const TMDB = require('src/tmdb/tmdb');
-const cache = new Cache();
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'));
 
 // there should be a translate function from query params to 
 // tmdb list that is valid. Should it be a helper function or does it 

--- a/seasoned_api/src/webserver/controllers/movie/credits.js
+++ b/seasoned_api/src/webserver/controllers/movie/credits.js
@@ -1,9 +1,7 @@
 const configuration = require('src/config/configuration').getInstance();
-const Cache = require('src/tmdb/cache');
 const TMDB = require('src/tmdb/tmdb');
 
-const cache = new Cache();
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'));
 
 const movieCreditsController = (req, res) => {
   const movieId = req.params.id;

--- a/seasoned_api/src/webserver/controllers/movie/info.js
+++ b/seasoned_api/src/webserver/controllers/movie/info.js
@@ -1,9 +1,7 @@
 const configuration = require('src/config/configuration').getInstance();
-const Cache = require('src/tmdb/cache');
 const TMDB = require('src/tmdb/tmdb');
 const Plex = require('src/plex/plex');
-const cache = new Cache();
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'));
 const plex = new Plex(configuration.get('plex', 'ip'));
 
 function handleError(error, res) {

--- a/seasoned_api/src/webserver/controllers/movie/releaseDates.js
+++ b/seasoned_api/src/webserver/controllers/movie/releaseDates.js
@@ -1,9 +1,7 @@
 const configuration = require('src/config/configuration').getInstance();
-const Cache = require('src/tmdb/cache');
 const TMDB = require('src/tmdb/tmdb');
 
-const cache = new Cache();
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'));
 
 const movieReleaseDatesController = (req, res) => {
   const movieId = req.params.id;

--- a/seasoned_api/src/webserver/controllers/person/info.js
+++ b/seasoned_api/src/webserver/controllers/person/info.js
@@ -1,8 +1,6 @@
 const configuration = require('src/config/configuration').getInstance();
-const Cache = require('src/tmdb/cache');
 const TMDB = require('src/tmdb/tmdb');
-const cache = new Cache();
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'));
 
 /**
  * Controller: Retrieve information for a person 

--- a/seasoned_api/src/webserver/controllers/plex/submitRequest.js
+++ b/seasoned_api/src/webserver/controllers/plex/submitRequest.js
@@ -1,10 +1,7 @@
 const configuration = require('src/config/configuration').getInstance()
 const RequestRepository = require('src/request/request');
-const Cache = require('src/tmdb/cache')
 const TMDB = require('src/tmdb/tmdb')
-
-const cache = new Cache()
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'))
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'))
 const request = new RequestRepository()
 
 const tmdbMovieInfo = (id) => {

--- a/seasoned_api/src/webserver/controllers/plex/watchDirectLink.js
+++ b/seasoned_api/src/webserver/controllers/plex/watchDirectLink.js
@@ -1,0 +1,27 @@
+const configuration = require('src/config/configuration').getInstance();
+const Plex = require('src/plex/plex');
+const plex = new Plex(configuration.get('plex', 'ip'));
+
+/**
+ * Controller: Search plex for movies, shows and episodes by query
+ * @param {Request} req http request variable
+ * @param {Response} res
+ * @returns {Callback}
+ */
+
+function watchDirectLink (req, res) {
+   const { title, year } = req.query;
+
+  plex.getDirectLinkByTitleAndYear(title, year)
+    .then(plexDirectLink => {
+      if (plexDirectLink == false)
+        res.status(404).send({ success: true, link: null })
+      else
+        res.status(200).send({ success: true, link: plexDirectLink })
+    })
+    .catch(error => {
+       res.status(500).send({ success: false, message: error.message });
+    });
+}
+
+module.exports = watchDirectLink;

--- a/seasoned_api/src/webserver/controllers/request/requestTmdbId.js
+++ b/seasoned_api/src/webserver/controllers/request/requestTmdbId.js
@@ -1,9 +1,7 @@
 const configuration = require('src/config/configuration').getInstance();
-const Cache = require('src/tmdb/cache');
 const TMDB = require('src/tmdb/tmdb');
 const RequestRepository = require('src/request/request');
-const cache = new Cache();
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'));
 const request = new RequestRepository();
 
 const tmdbMovieInfo = (id) => {

--- a/seasoned_api/src/webserver/controllers/search/movieSearch.js
+++ b/seasoned_api/src/webserver/controllers/search/movieSearch.js
@@ -1,9 +1,7 @@
 const configuration = require('src/config/configuration').getInstance();
-const Cache = require('src/tmdb/cache');
 const TMDB = require('src/tmdb/tmdb');
 const SearchHistory = require('src/searchHistory/searchHistory');
-const cache = new Cache();
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'));
 const searchHistory = new SearchHistory();
 
 /**

--- a/seasoned_api/src/webserver/controllers/search/multiSearch.js
+++ b/seasoned_api/src/webserver/controllers/search/multiSearch.js
@@ -1,9 +1,7 @@
 const configuration = require('src/config/configuration').getInstance();
-const Cache = require('src/tmdb/cache');
 const TMDB = require('src/tmdb/tmdb');
 const SearchHistory = require('src/searchHistory/searchHistory');
-const cache = new Cache();
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'));
 const searchHistory = new SearchHistory();
 
 function checkAndCreateJsonResponse(result) {

--- a/seasoned_api/src/webserver/controllers/search/personSearch.js
+++ b/seasoned_api/src/webserver/controllers/search/personSearch.js
@@ -1,9 +1,7 @@
 const configuration = require('src/config/configuration').getInstance();
-const Cache = require('src/tmdb/cache');
 const TMDB = require('src/tmdb/tmdb');
 const SearchHistory = require('src/searchHistory/searchHistory');
-const cache = new Cache();
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'));
 const searchHistory = new SearchHistory();
 
 /**

--- a/seasoned_api/src/webserver/controllers/search/showSearch.js
+++ b/seasoned_api/src/webserver/controllers/search/showSearch.js
@@ -1,9 +1,7 @@
 const SearchHistory = require('src/searchHistory/searchHistory');
 const configuration = require('src/config/configuration').getInstance();
-const Cache = require('src/tmdb/cache');
 const TMDB = require('src/tmdb/tmdb');
-const cache = new Cache();
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'));
 const searchHistory = new SearchHistory();
 
 /**

--- a/seasoned_api/src/webserver/controllers/show/credits.js
+++ b/seasoned_api/src/webserver/controllers/show/credits.js
@@ -1,9 +1,6 @@
 const configuration = require('src/config/configuration').getInstance();
-const Cache = require('src/tmdb/cache');
 const TMDB = require('src/tmdb/tmdb');
-
-const cache = new Cache();
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'));
 
 const showCreditsController = (req, res) => {
   const showId = req.params.id;

--- a/seasoned_api/src/webserver/controllers/show/info.js
+++ b/seasoned_api/src/webserver/controllers/show/info.js
@@ -1,9 +1,7 @@
 const configuration = require('src/config/configuration').getInstance();
-const Cache = require('src/tmdb/cache');
 const TMDB = require('src/tmdb/tmdb');
 const Plex = require('src/plex/plex');
-const cache = new Cache();
-const tmdb = new TMDB(cache, configuration.get('tmdb', 'apiKey'));
+const tmdb = new TMDB(configuration.get('tmdb', 'apiKey'));
 const plex = new Plex(configuration.get('plex', 'ip'));
 
 function handleError(error, res) {


### PR DESCRIPTION
Implemented Redis to cache responses from tmdb, piratesearch and plex. A new dependency, but the old way was caching in sql database so big improvement. 

Other notable changes:
 - TMDB constructor no longer has cache as first parameter. Now if not set Redis cache is used.