### PR TITLE
Feat: es modules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
 	"extends": ["eslint-config-airbnb-base", "plugin:prettier/recommended"],
 	"plugins": ["mocha"],
 	"rules": {
+		"import/extensions": 0,
 		"max-classes-per-file": 1,
 		"no-empty": [
 			2,

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "url": "https://www.opensource.org/licenses/mit-license.php"
   },
   "main": "webserver/server.js",
+  "type": "module",
   "scripts": {
     "start": "SEASONED_CONFIG=configurations/production.json NODE_ENV=production node src/webserver/server.js",
     "dev": "SEASONED_CONFIG=configurations/development.json NODE_ENV=development node src/webserver/server.js",

--- a/scripts/updateRequestsInPlex.js
+++ b/scripts/updateRequestsInPlex.js
@@ -1,7 +1,12 @@
-const Plex = require("src/plex/plex");
-const configuration = require("src/config/configuration").getInstance();
-const plex = new Plex(configuration.get("plex", "ip"));
-const establishedDatabase = require("src/database/database");
+import Plex from "../src/plex/plexRepository";
+import establishedDatabase from "../src/database/database";
+import Configuration from "../src/config/configuration";
+
+const configuration = Configuration.getInstance();
+const plex = new Plex(
+  configuration.get("plex", "ip"),
+  configuration.get("plex", "token")
+);
 
 const queries = {
   getRequestsNotYetInPlex: `SELECT * FROM requests WHERE status = 'requested' OR status = 'downloading'`,

--- a/src/cache/redis.js
+++ b/src/cache/redis.js
@@ -1,10 +1,11 @@
-const configuration = require("../config/configuration").getInstance();
+import redis from "redis";
+import Configuration from "../config/configuration";
 
+const configuration = Configuration.getInstance();
 let client;
 const mockCache = {};
 
 try {
-  const redis = require("redis"); // eslint-disable-line global-require
   console.log("Trying to connect with redis.."); // eslint-disable-line no-console
   const host = configuration.get("redis", "host");
   const port = configuration.get("redis", "port");
@@ -37,7 +38,7 @@ try {
   });
 } catch (e) {}
 
-function set(key, value, TTL = 10800) {
+export function set(key, value, TTL = 10800) {
   if (value == null || key == null) return null;
 
   const json = JSON.stringify(value);
@@ -60,7 +61,7 @@ function set(key, value, TTL = 10800) {
   return value;
 }
 
-function get(key) {
+export function get(key) {
   return new Promise((resolve, reject) => {
     client.get(key, (error, reply) => {
       if (reply === null) {
@@ -71,8 +72,3 @@ function get(key) {
     });
   });
 }
-
-module.exports = {
-  get,
-  set
-};

--- a/src/cache/redis.js
+++ b/src/cache/redis.js
@@ -1,5 +1,5 @@
 import redis from "redis";
-import Configuration from "../config/configuration";
+import Configuration from "../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 let client;
@@ -38,7 +38,7 @@ try {
   });
 } catch (e) {}
 
-export function set(key, value, TTL = 10800) {
+function set(key, value, TTL = 10800) {
   if (value == null || key == null) return null;
 
   const json = JSON.stringify(value);
@@ -61,7 +61,7 @@ export function set(key, value, TTL = 10800) {
   return value;
 }
 
-export function get(key) {
+function get(key) {
   return new Promise((resolve, reject) => {
     client.get(key, (error, reply) => {
       if (reply === null) {
@@ -72,3 +72,8 @@ export function get(key) {
     });
   });
 }
+
+export default {
+  set,
+  get
+};

--- a/src/config/configuration.js
+++ b/src/config/configuration.js
@@ -1,3 +1,4 @@
+import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -10,8 +11,7 @@ const __dirname = path.dirname(__filename);
 class Config {
   constructor() {
     this.location = Config.determineLocation();
-    // eslint-disable-next-line import/no-dynamic-require, global-require
-    this.fields = require(`${this.location}`);
+    this.fields = Config.readFileContents(this.location);
   }
 
   static getInstance() {
@@ -23,6 +23,17 @@ class Config {
 
   static determineLocation() {
     return path.join(__dirname, "..", "..", process.env.SEASONED_CONFIG);
+  }
+
+  static readFileContents(location) {
+    let content = {};
+    try {
+      content = JSON.parse(fs.readFileSync(location, { encoding: "utf-8" }));
+    } catch (err) {
+      console.error(`Error loading configuration file at path: ${location}`);
+    }
+
+    return content;
   }
 
   get(section, option) {

--- a/src/config/configuration.js
+++ b/src/config/configuration.js
@@ -1,5 +1,5 @@
-const path = require("path");
-const Field = require("./field");
+import path from "path";
+import Field from "./field";
 
 let instance = null;
 
@@ -45,4 +45,4 @@ class Config {
   }
 }
 
-module.exports = Config;
+export default Config;

--- a/src/config/configuration.js
+++ b/src/config/configuration.js
@@ -1,7 +1,11 @@
 import path from "path";
-import Field from "./field";
+import { fileURLToPath } from "url";
+
+import Field from "./field.js";
 
 let instance = null;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 class Config {
   constructor() {

--- a/src/config/environmentVariables.js
+++ b/src/config/environmentVariables.js
@@ -12,4 +12,4 @@ class EnvironmentVariables {
   }
 }
 
-module.exports = EnvironmentVariables;
+export default EnvironmentVariables;

--- a/src/config/field.js
+++ b/src/config/field.js
@@ -1,5 +1,5 @@
-import Filters from "./filters";
-import EnvironmentVariables from "./environmentVariables";
+import Filters from "./filters.js";
+import EnvironmentVariables from "./environmentVariables.js";
 
 class Field {
   constructor(rawValue, environmentVariables) {

--- a/src/config/field.js
+++ b/src/config/field.js
@@ -1,5 +1,5 @@
-const Filters = require("./filters");
-const EnvironmentVariables = require("./environmentVariables");
+import Filters from "./filters";
+import EnvironmentVariables from "./environmentVariables";
 
 class Field {
   constructor(rawValue, environmentVariables) {
@@ -50,4 +50,4 @@ class Field {
   }
 }
 
-module.exports = Field;
+export default Field;

--- a/src/config/filters.js
+++ b/src/config/filters.js
@@ -31,4 +31,4 @@ class Filters {
   }
 }
 
-module.exports = Filters;
+export default Filters;

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -1,5 +1,5 @@
-import SqliteDatabase from "./sqliteDatabase";
-import Configuration from "../config/configuration";
+import SqliteDatabase from "./sqliteDatabase.js";
+import Configuration from "../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -1,5 +1,7 @@
-const configuration = require("../config/configuration").getInstance();
-const SqliteDatabase = require("./sqliteDatabase");
+import SqliteDatabase from "./sqliteDatabase";
+import Configuration from "../config/configuration";
+
+const configuration = Configuration.getInstance();
 
 const database = new SqliteDatabase(configuration.get("database", "host"));
 /**
@@ -10,4 +12,4 @@ const database = new SqliteDatabase(configuration.get("database", "host"));
  */
 Promise.resolve().then(() => database.setUp());
 
-module.exports = database;
+export default database;

--- a/src/database/sqliteDatabase.js
+++ b/src/database/sqliteDatabase.js
@@ -1,6 +1,10 @@
 import fs from "fs";
 import path from "path";
 import sqlite3 from "sqlite3";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 class SqliteDatabase {
   constructor(host) {

--- a/src/database/sqliteDatabase.js
+++ b/src/database/sqliteDatabase.js
@@ -1,6 +1,6 @@
-const fs = require("fs");
-const path = require("path");
-const sqlite3 = require("sqlite3").verbose();
+import fs from "fs";
+import path from "path";
+import sqlite3 from "sqlite3";
 
 class SqliteDatabase {
   constructor(host) {
@@ -115,4 +115,4 @@ class SqliteDatabase {
   }
 }
 
-module.exports = SqliteDatabase;
+export default SqliteDatabase;

--- a/src/git/gitRepository.js
+++ b/src/git/gitRepository.js
@@ -5,4 +5,4 @@ class GitRepository {
   }
 }
 
-module.exports = GitRepository;
+export default GitRepository;

--- a/src/media_classes/media.js
+++ b/src/media_classes/media.js
@@ -15,4 +15,4 @@ class Media {
   }
 }
 
-module.exports = Media;
+export default Media;

--- a/src/media_classes/mediaInfo.js
+++ b/src/media_classes/mediaInfo.js
@@ -12,4 +12,4 @@ class MediaInfo {
   }
 }
 
-module.exports = MediaInfo;
+export default MediaInfo;

--- a/src/media_classes/player.js
+++ b/src/media_classes/player.js
@@ -9,4 +9,4 @@ class Player {
   }
 }
 
-module.exports = Player;
+export default Player;

--- a/src/media_classes/plex.js
+++ b/src/media_classes/plex.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 
-const Media = require("./media");
+import Media from "./media";
 
 class Plex extends Media {
   constructor(
@@ -30,4 +30,4 @@ class Plex extends Media {
   }
 }
 
-module.exports = Plex;
+export default Plex;

--- a/src/media_classes/plex.js
+++ b/src/media_classes/plex.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 
-import Media from "./media";
+import Media from "./media.js";
 
 class Plex extends Media {
   constructor(

--- a/src/media_classes/tmdb.js
+++ b/src/media_classes/tmdb.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import Media from "./media";
+import Media from "./media.js";
 
 class TMDB extends Media {
   // constructor(...args) {

--- a/src/media_classes/tmdb.js
+++ b/src/media_classes/tmdb.js
@@ -1,6 +1,5 @@
 /* eslint-disable camelcase */
-
-const Media = require("./media");
+import Media from "./media";
 
 class TMDB extends Media {
   // constructor(...args) {
@@ -45,4 +44,4 @@ class TMDB extends Media {
   }
 }
 
-module.exports = TMDB;
+export default TMDB;

--- a/src/media_classes/user.js
+++ b/src/media_classes/user.js
@@ -5,4 +5,4 @@ class User {
   }
 }
 
-module.exports = User;
+export default User;

--- a/src/notifications/sms.js
+++ b/src/notifications/sms.js
@@ -11,7 +11,7 @@ class SMSUnexpectedError extends Error {
   }
 }
 
-export function sendSMS(message) {
+export default function sendSMS(message) {
   const apiKey = configuration.get("sms", "apikey");
 
   if (!apiKey) {

--- a/src/notifications/sms.js
+++ b/src/notifications/sms.js
@@ -1,4 +1,6 @@
-const configuration = require("../config/configuration").getInstance();
+import Configuration from "../config/configuration";
+
+const configuration = Configuration.getInstance();
 
 class SMSUnexpectedError extends Error {
   constructor(errorMessage) {
@@ -9,7 +11,7 @@ class SMSUnexpectedError extends Error {
   }
 }
 
-const sendSMS = message => {
+export function sendSMS(message) {
   const apiKey = configuration.get("sms", "apikey");
 
   if (!apiKey) {
@@ -35,6 +37,4 @@ const sendSMS = message => {
       .then(response => resolve(response))
       .catch(error => reject(new SMSUnexpectedError(error)));
   });
-};
-
-module.exports = { sendSMS };
+}

--- a/src/notifications/sms.js
+++ b/src/notifications/sms.js
@@ -1,4 +1,4 @@
-import Configuration from "../config/configuration";
+import Configuration from "../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 

--- a/src/pirate/pirateRepository.js
+++ b/src/pirate/pirateRepository.js
@@ -1,10 +1,9 @@
-const http = require("http");
-const { URL } = require("url");
-const PythonShell = require("python-shell");
+import http from "http";
+import { URL } from "url";
+import PythonShell from "python-shell";
 
-const establishedDatabase = require("../database/database");
-
-const cache = require("../cache/redis");
+import establishedDatabase from "../database/database";
+import cache from "../cache/redis";
 
 function getMagnetFromURL(url) {
   return new Promise(resolve => {
@@ -46,7 +45,7 @@ async function callPythonAddMagnet(url, callback) {
     });
 }
 
-async function SearchPiratebay(_query) {
+export async function SearchPiratebay(_query) {
   let query = String(_query);
 
   if (query?.includes("+")) {
@@ -76,7 +75,7 @@ async function SearchPiratebay(_query) {
   );
 }
 
-function AddMagnet(magnet, name, tmdbId) {
+export function AddMagnet(magnet, name, tmdbId) {
   return new Promise((resolve, reject) =>
     callPythonAddMagnet(magnet, (err, results) => {
       if (err) {
@@ -98,5 +97,3 @@ function AddMagnet(magnet, name, tmdbId) {
     })
   );
 }
-
-module.exports = { SearchPiratebay, AddMagnet };

--- a/src/pirate/pirateRepository.js
+++ b/src/pirate/pirateRepository.js
@@ -2,8 +2,8 @@ import http from "http";
 import { URL } from "url";
 import PythonShell from "python-shell";
 
-import establishedDatabase from "../database/database";
-import cache from "../cache/redis";
+import establishedDatabase from "../database/database.js";
+import cache from "../cache/redis.js";
 
 function getMagnetFromURL(url) {
   return new Promise(resolve => {

--- a/src/plex/convertPlexToEpisode.js
+++ b/src/plex/convertPlexToEpisode.js
@@ -1,4 +1,4 @@
-import Episode from "./types/episode";
+import Episode from "./types/episode.js";
 
 function convertPlexToEpisode(plexEpisode) {
   const episode = new Episode(

--- a/src/plex/convertPlexToEpisode.js
+++ b/src/plex/convertPlexToEpisode.js
@@ -1,4 +1,4 @@
-const Episode = require("./types/episode");
+import Episode from "./types/episode";
 
 function convertPlexToEpisode(plexEpisode) {
   const episode = new Episode(
@@ -21,4 +21,5 @@ function convertPlexToEpisode(plexEpisode) {
 
   return episode;
 }
-module.exports = convertPlexToEpisode;
+
+export default convertPlexToEpisode;

--- a/src/plex/convertPlexToMovie.js
+++ b/src/plex/convertPlexToMovie.js
@@ -1,4 +1,4 @@
-const Movie = require("./types/movie");
+import Movie from "./types/movie";
 
 function convertPlexToMovie(plexMovie) {
   const movie = new Movie(plexMovie.title, plexMovie.year);
@@ -12,4 +12,4 @@ function convertPlexToMovie(plexMovie) {
   return movie;
 }
 
-module.exports = convertPlexToMovie;
+export default convertPlexToMovie;

--- a/src/plex/convertPlexToMovie.js
+++ b/src/plex/convertPlexToMovie.js
@@ -1,4 +1,4 @@
-import Movie from "./types/movie";
+import Movie from "./types/movie.js";
 
 function convertPlexToMovie(plexMovie) {
   const movie = new Movie(plexMovie.title, plexMovie.year);

--- a/src/plex/convertPlexToSeasoned.js
+++ b/src/plex/convertPlexToSeasoned.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 
-import Plex from "../media_classes/plex";
+import Plex from "../media_classes/plex.js";
 
 function translateAdded(date_string) {
   return new Date(date_string * 1000);

--- a/src/plex/convertPlexToSeasoned.js
+++ b/src/plex/convertPlexToSeasoned.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 
-const Plex = require("../media_classes/plex");
+import Plex from "../media_classes/plex";
 
 function translateAdded(date_string) {
   return new Date(date_string * 1000);
@@ -32,4 +32,4 @@ function convertPlexToSeasoned(plex) {
   return seasoned;
 }
 
-module.exports = convertPlexToSeasoned;
+export default convertPlexToSeasoned;

--- a/src/plex/convertPlexToShow.js
+++ b/src/plex/convertPlexToShow.js
@@ -1,4 +1,4 @@
-import Show from "./types/show";
+import Show from "./types/show.js";
 
 function convertPlexToShow(plexShow) {
   const show = new Show(plexShow.title, plexShow.year);

--- a/src/plex/convertPlexToShow.js
+++ b/src/plex/convertPlexToShow.js
@@ -1,4 +1,4 @@
-const Show = require("./types/show");
+import Show from "./types/show";
 
 function convertPlexToShow(plexShow) {
   const show = new Show(plexShow.title, plexShow.year);
@@ -10,4 +10,4 @@ function convertPlexToShow(plexShow) {
   return show;
 }
 
-module.exports = convertPlexToShow;
+export default convertPlexToShow;

--- a/src/plex/convertPlexToStream.js
+++ b/src/plex/convertPlexToStream.js
@@ -1,8 +1,8 @@
-import convertPlexToSeasoned from "./convertPlexToSeasoned";
-import convertStreamToMediaInfo from "./convertStreamToMediaInfo";
-import convertStreamToPlayer from "./stream/convertStreamToPlayer";
-import convertStreamToUser from "./stream/convertStreamToUser";
-import ConvertStreamToPlayback from "./stream/convertStreamToPlayback";
+import convertPlexToSeasoned from "./convertPlexToSeasoned.js";
+import convertStreamToMediaInfo from "./convertStreamToMediaInfo.js";
+import convertStreamToPlayer from "./stream/convertStreamToPlayer.js";
+import convertStreamToUser from "./stream/convertStreamToUser.js";
+import ConvertStreamToPlayback from "./stream/convertStreamToPlayback.js";
 
 function convertPlexToStream(plexStream) {
   const stream = convertPlexToSeasoned(plexStream);

--- a/src/plex/convertPlexToStream.js
+++ b/src/plex/convertPlexToStream.js
@@ -1,8 +1,8 @@
-const convertPlexToSeasoned = require("./convertPlexToSeasoned");
-const convertStreamToMediaInfo = require("./convertStreamToMediaInfo");
-const convertStreamToPlayer = require("./stream/convertStreamToPlayer");
-const convertStreamToUser = require("./stream/convertStreamToUser");
-const ConvertStreamToPlayback = require("./stream/convertStreamToPlayback");
+import convertPlexToSeasoned from "./convertPlexToSeasoned";
+import convertStreamToMediaInfo from "./convertStreamToMediaInfo";
+import convertStreamToPlayer from "./stream/convertStreamToPlayer";
+import convertStreamToUser from "./stream/convertStreamToUser";
+import ConvertStreamToPlayback from "./stream/convertStreamToPlayback";
 
 function convertPlexToStream(plexStream) {
   const stream = convertPlexToSeasoned(plexStream);
@@ -16,4 +16,4 @@ function convertPlexToStream(plexStream) {
   return stream;
 }
 
-module.exports = convertPlexToStream;
+export default convertPlexToStream;

--- a/src/plex/convertStreamToMediaInfo.js
+++ b/src/plex/convertStreamToMediaInfo.js
@@ -1,4 +1,4 @@
-import MediaInfo from "../media_classes/mediaInfo";
+import MediaInfo from "../media_classes/mediaInfo.js";
 
 function convertStreamToMediaInfo(plexStream) {
   const mediaInfo = new MediaInfo();

--- a/src/plex/convertStreamToMediaInfo.js
+++ b/src/plex/convertStreamToMediaInfo.js
@@ -1,4 +1,4 @@
-const MediaInfo = require("../media_classes/mediaInfo");
+import MediaInfo from "../media_classes/mediaInfo";
 
 function convertStreamToMediaInfo(plexStream) {
   const mediaInfo = new MediaInfo();
@@ -19,4 +19,4 @@ function convertStreamToMediaInfo(plexStream) {
   return mediaInfo;
 }
 
-module.exports = convertStreamToMediaInfo;
+export default convertStreamToMediaInfo;

--- a/src/plex/mailTemplate.js
+++ b/src/plex/mailTemplate.js
@@ -22,4 +22,4 @@ class mailTemplate {
   }
 }
 
-module.exports = mailTemplate;
+export default mailTemplate;

--- a/src/plex/plex.js
+++ b/src/plex/plex.js
@@ -1,7 +1,7 @@
-import convertPlexToMovie from "./convertPlexToMovie";
-import convertPlexToShow from "./convertPlexToShow";
-import convertPlexToEpisode from "./convertPlexToEpisode";
-import redisCache from "../cache/redis";
+import convertPlexToMovie from "./convertPlexToMovie.js";
+import convertPlexToShow from "./convertPlexToShow.js";
+import convertPlexToEpisode from "./convertPlexToEpisode.js";
+import redisCache from "../cache/redis.js";
 
 class PlexRequestTimeoutError extends Error {
   constructor() {

--- a/src/plex/plex.js
+++ b/src/plex/plex.js
@@ -1,7 +1,7 @@
-const convertPlexToMovie = require("./convertPlexToMovie");
-const convertPlexToShow = require("./convertPlexToShow");
-const convertPlexToEpisode = require("./convertPlexToEpisode");
-const redisCache = require("../cache/redis");
+import convertPlexToMovie from "./convertPlexToMovie";
+import convertPlexToShow from "./convertPlexToShow";
+import convertPlexToEpisode from "./convertPlexToEpisode";
+import redisCache from "../cache/redis";
 
 class PlexRequestTimeoutError extends Error {
   constructor() {
@@ -227,4 +227,4 @@ class Plex {
   }
 }
 
-module.exports = Plex;
+export default Plex;

--- a/src/plex/plexRepository.js
+++ b/src/plex/plexRepository.js
@@ -1,5 +1,5 @@
-import convertPlexToSeasoned from "./convertPlexToSeasoned";
-import convertPlexToStream from "./convertPlexToStream";
+import convertPlexToSeasoned from "./convertPlexToSeasoned.js";
+import convertPlexToStream from "./convertPlexToStream.js";
 
 // eslint-disable-next-line
 function addAttributeIfTmdbInPlex(_tmdb, plexResult) {

--- a/src/plex/plexRepository.js
+++ b/src/plex/plexRepository.js
@@ -1,5 +1,5 @@
-const convertPlexToSeasoned = require("./convertPlexToSeasoned");
-const convertPlexToStream = require("./convertPlexToStream");
+import convertPlexToSeasoned from "./convertPlexToSeasoned";
+import convertPlexToStream from "./convertPlexToStream";
 
 // eslint-disable-next-line
 function addAttributeIfTmdbInPlex(_tmdb, plexResult) {
@@ -103,4 +103,4 @@ class PlexRepository {
   // }
 }
 
-module.exports = PlexRepository;
+export default PlexRepository;

--- a/src/plex/requestRepository.js
+++ b/src/plex/requestRepository.js
@@ -1,7 +1,7 @@
-import PlexRepository from "./plexRepository";
-import TMDB from "../tmdb/tmdb";
-import establishedDatabase from "../database/database";
-import Configuration from "../config/configuration";
+import PlexRepository from "./plexRepository.js";
+import TMDB from "../tmdb/tmdb.js";
+import establishedDatabase from "../database/database.js";
+import Configuration from "../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const plexRepository = new PlexRepository(

--- a/src/plex/requestRepository.js
+++ b/src/plex/requestRepository.js
@@ -1,8 +1,9 @@
-const PlexRepository = require("./plexRepository");
-const configuration = require("../config/configuration").getInstance();
-const TMDB = require("../tmdb/tmdb");
-const establishedDatabase = require("../database/database");
+import PlexRepository from "./plexRepository";
+import TMDB from "../tmdb/tmdb";
+import establishedDatabase from "../database/database";
+import Configuration from "../config/configuration";
 
+const configuration = Configuration.getInstance();
 const plexRepository = new PlexRepository(
   configuration.get("plex", "ip"),
   configuration.get("plex", "token")
@@ -128,4 +129,4 @@ class RequestRepository {
   }
 }
 
-module.exports = RequestRepository;
+export default RequestRepository;

--- a/src/plex/stream/convertStreamToPlayback.js
+++ b/src/plex/stream/convertStreamToPlayback.js
@@ -11,4 +11,4 @@ class convertStreamToPlayback {
   }
 }
 
-module.exports = convertStreamToPlayback;
+export default convertStreamToPlayback;

--- a/src/plex/stream/convertStreamToPlayer.js
+++ b/src/plex/stream/convertStreamToPlayer.js
@@ -1,4 +1,4 @@
-import Player from "../../media_classes/player";
+import Player from "../../media_classes/player.js";
 
 function convertStreamToPlayer(plexStream) {
   const player = new Player(plexStream.device, plexStream.address);

--- a/src/plex/stream/convertStreamToPlayer.js
+++ b/src/plex/stream/convertStreamToPlayer.js
@@ -1,4 +1,4 @@
-const Player = require("../../media_classes/player");
+import Player from "../../media_classes/player";
 
 function convertStreamToPlayer(plexStream) {
   const player = new Player(plexStream.device, plexStream.address);
@@ -10,4 +10,4 @@ function convertStreamToPlayer(plexStream) {
   return player;
 }
 
-module.exports = convertStreamToPlayer;
+export default convertStreamToPlayer;

--- a/src/plex/stream/convertStreamToUser.js
+++ b/src/plex/stream/convertStreamToUser.js
@@ -1,4 +1,4 @@
-import User from "../../media_classes/user";
+import User from "../../media_classes/user.js";
 
 function convertStreamToUser(plexStream) {
   return new User(plexStream.id, plexStream.title);

--- a/src/plex/stream/convertStreamToUser.js
+++ b/src/plex/stream/convertStreamToUser.js
@@ -1,7 +1,7 @@
-const User = require("../../media_classes/user");
+import User from "../../media_classes/user";
 
 function convertStreamToUser(plexStream) {
   return new User(plexStream.id, plexStream.title);
 }
 
-module.exports = convertStreamToUser;
+export default convertStreamToUser;

--- a/src/plex/types/episode.js
+++ b/src/plex/types/episode.js
@@ -13,4 +13,4 @@ class Episode {
   }
 }
 
-module.exports = Episode;
+export default Episode;

--- a/src/plex/types/movie.js
+++ b/src/plex/types/movie.js
@@ -9,4 +9,4 @@ class Movie {
   }
 }
 
-module.exports = Movie;
+export default Movie;

--- a/src/plex/types/show.js
+++ b/src/plex/types/show.js
@@ -9,4 +9,4 @@ class Show {
   }
 }
 
-module.exports = Show;
+export default Show;

--- a/src/request/request.js
+++ b/src/request/request.js
@@ -1,7 +1,7 @@
-const assert = require("assert");
+import assert from "assert";
 // const configuration = require("../config/configuration").getInstance();
 // const TMDB = require("../tmdb/tmdb");
-const establishedDatabase = require("../database/database");
+import establishedDatabase from "../database/database";
 
 // const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 
@@ -156,4 +156,4 @@ class RequestRepository {
   }
 }
 
-module.exports = RequestRepository;
+export default RequestRepository;

--- a/src/request/request.js
+++ b/src/request/request.js
@@ -1,7 +1,7 @@
 import assert from "assert";
 // const configuration = require("../config/configuration").getInstance();
 // const TMDB = require("../tmdb/tmdb");
-import establishedDatabase from "../database/database";
+import establishedDatabase from "../database/database.js";
 
 // const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 

--- a/src/request/utils.js
+++ b/src/request/utils.js
@@ -45,4 +45,4 @@ function validFilter(filterParam) {
   });
 }
 
-module.exports = { validSort, validFilter };
+export default { validSort, validFilter };

--- a/src/searchHistory/searchHistory.js
+++ b/src/searchHistory/searchHistory.js
@@ -1,4 +1,4 @@
-const establishedDatabase = require("../database/database");
+import establishedDatabase from "../database/database";
 
 class SearchHistoryCreateDatabaseError extends Error {
   constructor(message = "an unexpected error occured", errorResponse = null) {
@@ -55,4 +55,4 @@ class SearchHistory {
   }
 }
 
-module.exports = SearchHistory;
+export default SearchHistory;

--- a/src/searchHistory/searchHistory.js
+++ b/src/searchHistory/searchHistory.js
@@ -1,4 +1,4 @@
-import establishedDatabase from "../database/database";
+import establishedDatabase from "../database/database.js";
 
 class SearchHistoryCreateDatabaseError extends Error {
   constructor(message = "an unexpected error occured", errorResponse = null) {

--- a/src/seasoned/stray.js
+++ b/src/seasoned/stray.js
@@ -4,4 +4,4 @@ class Stray {
   }
 }
 
-module.exports = Stray;
+export default Stray;

--- a/src/seasoned/strayRepository.js
+++ b/src/seasoned/strayRepository.js
@@ -1,7 +1,7 @@
 import assert from "assert";
 import pythonShell from "python-shell";
-import Stray from "./stray";
-import establishedDatabase from "../database/database";
+import Stray from "./stray.js";
+import establishedDatabase from "../database/database.js";
 
 class StrayRepository {
   constructor(database) {

--- a/src/seasoned/strayRepository.js
+++ b/src/seasoned/strayRepository.js
@@ -1,7 +1,7 @@
-const assert = require("assert");
-const pythonShell = require("python-shell");
-const Stray = require("./stray");
-const establishedDatabase = require("../database/database");
+import assert from "assert";
+import pythonShell from "python-shell";
+import Stray from "./stray";
+import establishedDatabase from "../database/database";
 
 class StrayRepository {
   constructor(database) {
@@ -65,4 +65,4 @@ class StrayRepository {
   }
 }
 
-module.exports = StrayRepository;
+export default StrayRepository;

--- a/src/tautulli/tautulli.js
+++ b/src/tautulli/tautulli.js
@@ -75,4 +75,4 @@ class Tautulli {
   }
 }
 
-module.exports = Tautulli;
+export default Tautulli;

--- a/src/tmdb/cache.js
+++ b/src/tmdb/cache.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const establishedDatabase = require("../database/database");
+import assert from "assert";
+import establishedDatabase from "../database/database";
 
 class Cache {
   constructor(database) {
@@ -45,4 +45,4 @@ class Cache {
   }
 }
 
-module.exports = Cache;
+export default Cache;

--- a/src/tmdb/cache.js
+++ b/src/tmdb/cache.js
@@ -1,5 +1,5 @@
 import assert from "assert";
-import establishedDatabase from "../database/database";
+import establishedDatabase from "../database/database.js";
 
 class Cache {
   constructor(database) {

--- a/src/tmdb/tmdb.js
+++ b/src/tmdb/tmdb.js
@@ -1,7 +1,7 @@
 import moviedb from "km-moviedb";
-import redisCache from "../cache/redis";
+import redisCache from "../cache/redis.js";
 
-const { Movie, Show, Person, Credits, ReleaseDates } = require("./types");
+import { Movie, Show, Person, Credits, ReleaseDates } from "./types.js";
 
 class TMDBNotFoundError extends Error {
   constructor(message) {

--- a/src/tmdb/tmdb.js
+++ b/src/tmdb/tmdb.js
@@ -1,5 +1,5 @@
-const moviedb = require("km-moviedb");
-const redisCache = require("../cache/redis");
+import moviedb from "km-moviedb";
+import redisCache from "../cache/redis";
 
 const { Movie, Show, Person, Credits, ReleaseDates } = require("./types");
 
@@ -339,4 +339,4 @@ class TMDB {
   }
 }
 
-module.exports = TMDB;
+export default TMDB;

--- a/src/tmdb/types.js
+++ b/src/tmdb/types.js
@@ -1,7 +1,7 @@
-const Movie = require("./types/movie");
-const Show = require("./types/show");
-const Person = require("./types/person");
-const Credits = require("./types/credits");
-const ReleaseDates = require("./types/releaseDates");
+import Movie from "./types/movie";
+import Show from "./types/show";
+import Person from "./types/person";
+import Credits from "./types/credits";
+import ReleaseDates from "./types/releaseDates";
 
-module.exports = { Movie, Show, Person, Credits, ReleaseDates };
+export default { Movie, Show, Person, Credits, ReleaseDates };

--- a/src/tmdb/types.js
+++ b/src/tmdb/types.js
@@ -1,7 +1,7 @@
-import Movie from "./types/movie";
-import Show from "./types/show";
-import Person from "./types/person";
-import Credits from "./types/credits";
-import ReleaseDates from "./types/releaseDates";
+import Movie from "./types/movie.js";
+import Show from "./types/show.js";
+import Person from "./types/person.js";
+import Credits from "./types/credits.js";
+import ReleaseDates from "./types/releaseDates.js";
 
-export default { Movie, Show, Person, Credits, ReleaseDates };
+export { Movie, Show, Person, Credits, ReleaseDates };

--- a/src/tmdb/types/credits.js
+++ b/src/tmdb/types/credits.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
-import Movie from "./movie";
-import Show from "./show";
+import Movie from "./movie.js";
+import Show from "./show.js";
 
 class CreditedMovie extends Movie {}
 class CreditedShow extends Show {}

--- a/src/tmdb/types/credits.js
+++ b/src/tmdb/types/credits.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
-const Movie = require("./movie");
-const Show = require("./show");
+import Movie from "./movie";
+import Show from "./show";
 
 class CreditedMovie extends Movie {}
 class CreditedShow extends Show {}
@@ -113,4 +113,4 @@ class Credits {
   }
 }
 
-module.exports = Credits;
+export default Credits;

--- a/src/tmdb/types/movie.js
+++ b/src/tmdb/types/movie.js
@@ -113,4 +113,4 @@ class Movie {
   }
 }
 
-module.exports = Movie;
+export default Movie;

--- a/src/tmdb/types/person.js
+++ b/src/tmdb/types/person.js
@@ -69,4 +69,4 @@ class Person {
   }
 }
 
-module.exports = Person;
+export default Person;

--- a/src/tmdb/types/releaseDates.js
+++ b/src/tmdb/types/releaseDates.js
@@ -89,4 +89,4 @@ class ReleaseDates {
   }
 }
 
-module.exports = ReleaseDates;
+export default ReleaseDates;

--- a/src/tmdb/types/show.js
+++ b/src/tmdb/types/show.js
@@ -86,4 +86,4 @@ class Show {
   }
 }
 
-module.exports = Show;
+export default Show;

--- a/src/user/token.js
+++ b/src/user/token.js
@@ -1,5 +1,5 @@
-const jwt = require("jsonwebtoken");
-const User = require("./user");
+import jwt from "jsonwebtoken";
+import User from "./user";
 
 class Token {
   constructor(user, admin = false, settings = null) {
@@ -38,4 +38,4 @@ class Token {
   }
 }
 
-module.exports = Token;
+export default Token;

--- a/src/user/token.js
+++ b/src/user/token.js
@@ -1,5 +1,5 @@
 import jwt from "jsonwebtoken";
-import User from "./user";
+import User from "./user.js";
 
 class Token {
   constructor(user, admin = false, settings = null) {

--- a/src/user/user.js
+++ b/src/user/user.js
@@ -5,4 +5,4 @@ class User {
   }
 }
 
-module.exports = User;
+export default User;

--- a/src/user/userRepository.js
+++ b/src/user/userRepository.js
@@ -1,5 +1,5 @@
 import assert from "assert";
-import establishedDatabase from "../database/database";
+import establishedDatabase from "../database/database.js";
 
 class LinkPlexUserError extends Error {
   constructor(errorMessage = null) {

--- a/src/user/userRepository.js
+++ b/src/user/userRepository.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const establishedDatabase = require("../database/database");
+import assert from "assert";
+import establishedDatabase from "../database/database";
 
 class LinkPlexUserError extends Error {
   constructor(errorMessage = null) {
@@ -263,4 +263,4 @@ class UserRepository {
   }
 }
 
-module.exports = UserRepository;
+export default UserRepository;

--- a/src/user/userSecurity.js
+++ b/src/user/userSecurity.js
@@ -1,5 +1,5 @@
-const bcrypt = require("bcrypt");
-const UserRepository = require("./userRepository");
+import bcrypt from "bcrypt";
+import UserRepository from "./userRepository";
 
 class UserSecurity {
   constructor(database) {
@@ -72,4 +72,4 @@ class UserSecurity {
   }
 }
 
-module.exports = UserSecurity;
+export default UserSecurity;

--- a/src/user/userSecurity.js
+++ b/src/user/userSecurity.js
@@ -1,5 +1,5 @@
 import bcrypt from "bcrypt";
-import UserRepository from "./userRepository";
+import UserRepository from "./userRepository.js";
 
 class UserSecurity {
   constructor(database) {

--- a/src/webserver/app.js
+++ b/src/webserver/app.js
@@ -3,67 +3,69 @@ import Raven from "raven";
 import cookieParser from "cookie-parser";
 import bodyParser from "body-parser";
 
-import Configuration from "../config/configuration";
-
-import reqTokenToUser from "./middleware/reqTokenToUser";
-import mustBeAuthenticated from "./middleware/mustBeAuthenticated";
-import mustBeAdmin from "./middleware/mustBeAdmin";
-import mustHaveAccountLinkedToPlex from "./middleware/mustHaveAccountLinkedToPlex";
-
-import listController from "./controllers/list/listController";
-import tautulli from "./controllers/user/viewHistory";
-import SettingsController from "./controllers/user/settings";
-import AuthenticatePlexAccountController from "./controllers/user/authenticatePlexAccount";
-
+import Configuration from "../config/configuration.js";
 const configuration = Configuration.getInstance();
 
-import UserRegisterController from "./controller/user/register";
-import UserLoginController from "./controller/user/login";
-import UserLogoutController from "./controller/user/logout";
-import UserSearchHistoryController from "./controllers/user/searchHistory";
-import UserRequestsController from "./controllers/user/requests";
+import reqTokenToUser from "./middleware/reqTokenToUser.js";
+import mustBeAuthenticated from "./middleware/mustBeAuthenticated.js";
+import mustBeAdmin from "./middleware/mustBeAdmin.js";
+import mustHaveAccountLinkedToPlex from "./middleware/mustHaveAccountLinkedToPlex.js";
 
-import SearchMultiController from "./controllers/search/multiSearch";
-import SearchMovieController from "./controllers/search/movieSearch";
-import SearchShowController from "./controllers/search/showSearch";
-import SearchPersonController from "./controllers/search/personSearch";
+import tautulli from "./controllers/user/viewHistory.js";
+import {
+  getSettingsController,
+  updateSettingsController
+} from "./controllers/user/settings.js";
+import AuthenticatePlexAccountController from "./controllers/user/authenticatePlexAccount.js";
 
-import MovieCreditsController from "./controllers/movie/credits";
-import MovieReleaseDatesController from "./controllers/movie/releaseDates";
-import MovieInfoController from "./controllers/movie/info";
+import UserRegisterController from "./controllers/user/register.js";
+import UserLoginController from "./controllers/user/login.js";
+import UserLogoutController from "./controllers/user/logout.js";
+import UserSearchHistoryController from "./controllers/user/searchHistory.js";
+import UserRequestsController from "./controllers/user/requests.js";
 
-import ShowCreditsController from "./controllers/show/credits";
-import ShowInfoController from "./controllers/show/info";
+import SearchMultiController from "./controllers/search/multiSearch.js";
+import SearchMovieController from "./controllers/search/movieSearch.js";
+import SearchShowController from "./controllers/search/showSearch.js";
+import SearchPersonController from "./controllers/search/personSearch.js";
 
-import PersonCreditsController from "./controllers/person/credits";
-import PersonInfoController from "./controllers/person/info";
+import listController from "./controllers/list/listController.js";
 
-import SeasonedAllController from "./controllers/seasoned/readStrays";
-import SeasonedInfoController from "./controllers/seasoned/strayById";
-import SeasonedVerifyController from "./controllers/seasoned/verifyStray";
+import MovieCreditsController from "./controllers/movie/credits.js";
+import MovieReleaseDatesController from "./controllers/movie/releaseDates.js";
+import MovieInfoController from "./controllers/movie/info.js";
 
-import PlexSearchController from "./controllers/plex/search";
-import PlexRequestsAllController from "./controllres/plex/requests/all";
-import PlexRequestsInfo from "./controllers/plex/updateRequested";
-import PlexWatchLinkController from "./controllers/plex/watchDirectLink";
-import PlexHookController from "./controllers/plex/hookDump";
-import PlexSubmitRequestController from "./controllers/plex/submitRequest";
-import PlexRequestInfo from "./controllers/plex/readRequest";
-import PlexSearchRequestController from "./controllers/plex/searchRequest";
-import PlexPlayingController from "./controllers/plex/plexPlaying";
-import PlexSearchMediaController from "./controllres/plex/searchMedia";
-import PlexUpdateRequestedController from "./controllers/plex/updateRequested";
+import ShowCreditsController from "./controllers/show/credits.js";
+import ShowInfoController from "./controllers/show/info.js";
 
-import RequestFetchAllController from "./controllers/request/fetchAllRequests";
-import RequestAllController from "./controllers/plex/fetchRequested";
-import RequestInfoController from "./controllers/request/getRequest";
-import RequestSubmitController from "./controllers/request/requestTmdbId";
+import PersonCreditsController from "./controllers/person/credits.js";
+import PersonInfoController from "./controllers/person/info.js";
 
-import PirateSearchController from "./controllers/pirate/search";
-import PirateAddController from "./controllers/pirate/addMagnet";
+import SeasonedAllController from "./controllers/seasoned/readStrays.js";
+import SeasonedInfoController from "./controllers/seasoned/strayById.js";
+import SeasonedVerifyController from "./controllers/seasoned/verifyStray.js";
 
-import GitDumpController from "./controllres/git/dump";
-import EmojiController from "./controllers/misc/emoji";
+import PlexSearchController from "./controllers/plex/search.js";
+import PlexFetchRequestedController from "./controllers/plex/fetchRequested.js";
+import PlexRequestsInfo from "./controllers/plex/updateRequested.js";
+import PlexWatchLinkController from "./controllers/plex/watchDirectLink.js";
+import PlexHookController from "./controllers/plex/hookDump.js";
+import PlexSubmitRequestController from "./controllers/plex/submitRequest.js";
+import PlexRequestInfo from "./controllers/plex/readRequest.js";
+import PlexSearchRequestController from "./controllers/plex/searchRequest.js";
+import PlexPlayingController from "./controllers/plex/plexPlaying.js";
+import PlexSearchMediaController from "./controllers/plex/searchMedia.js";
+import PlexUpdateRequestedController from "./controllers/plex/updateRequested.js";
+
+import RequestFetchAllController from "./controllers/request/fetchAllRequests.js";
+import RequestInfoController from "./controllers/request/getRequest.js";
+import RequestSubmitController from "./controllers/request/requestTmdbId.js";
+
+import PirateSearchController from "./controllers/pirate/searchTheBay.js";
+import PirateAddController from "./controllers/pirate/addMagnet.js";
+
+import GitDumpController from "./controllers/git/dumpHook.js";
+import EmojiController from "./controllers/misc/emoji.js";
 
 // TODO: Have our raven router check if there is a value, if not don't enable raven.
 Raven.config(configuration.get("raven", "DSN")).install();
@@ -119,16 +121,8 @@ router.post("/v1/user", UserRegisterController);
 router.post("/v1/user/login", UserLoginController);
 router.post("/v1/user/logout", UserLogoutController);
 
-router.get(
-  "/v1/user/settings",
-  mustBeAuthenticated,
-  SettingsController.getSettingsController
-);
-router.put(
-  "/v1/user/settings",
-  mustBeAuthenticated,
-  SettingsController.updateSettingsController
-);
+router.get("/v1/user/settings", mustBeAuthenticated, getSettingsController);
+router.put("/v1/user/settings", mustBeAuthenticated, updateSettingsController);
 router.get(
   "/v1/user/search_history",
   mustBeAuthenticated,
@@ -220,7 +214,7 @@ router.get("/v1/plex/watch-link", mustBeAuthenticated, PlexWatchLinkController);
 router.get("/v2/request", RequestFetchAllController);
 router.get("/v2/request/:id", RequestInfoController);
 router.post("/v2/request", RequestSubmitController);
-router.get("/v1/plex/requests/all", RequestAllController);
+router.get("/v1/plex/requests/all", PlexFetchRequestedController);
 router.put(
   "/v1/plex/request/:requestId",
   mustBeAuthenticated,

--- a/src/webserver/app.js
+++ b/src/webserver/app.js
@@ -4,7 +4,6 @@ import cookieParser from "cookie-parser";
 import bodyParser from "body-parser";
 
 import Configuration from "../config/configuration.js";
-const configuration = Configuration.getInstance();
 
 import reqTokenToUser from "./middleware/reqTokenToUser.js";
 import mustBeAuthenticated from "./middleware/mustBeAuthenticated.js";
@@ -47,7 +46,7 @@ import SeasonedVerifyController from "./controllers/seasoned/verifyStray.js";
 
 import PlexSearchController from "./controllers/plex/search.js";
 import PlexFetchRequestedController from "./controllers/plex/fetchRequested.js";
-import PlexRequestsInfo from "./controllers/plex/updateRequested.js";
+// import PlexRequestsInfo from "./controllers/plex/updateRequested.js";
 import PlexWatchLinkController from "./controllers/plex/watchDirectLink.js";
 import PlexHookController from "./controllers/plex/hookDump.js";
 import PlexSubmitRequestController from "./controllers/plex/submitRequest.js";
@@ -67,6 +66,7 @@ import PirateAddController from "./controllers/pirate/addMagnet.js";
 import GitDumpController from "./controllers/git/dumpHook.js";
 import EmojiController from "./controllers/misc/emoji.js";
 
+const configuration = Configuration.getInstance();
 // TODO: Have our raven router check if there is a value, if not don't enable raven.
 Raven.config(configuration.get("raven", "DSN")).install();
 

--- a/src/webserver/app.js
+++ b/src/webserver/app.js
@@ -1,19 +1,69 @@
-const express = require("express");
-const Raven = require("raven");
-const cookieParser = require("cookie-parser");
-const bodyParser = require("body-parser");
+import express from "express";
+import Raven from "raven";
+import cookieParser from "cookie-parser";
+import bodyParser from "body-parser";
 
-const configuration = require("../config/configuration").getInstance();
+import Configuration from "../config/configuration";
 
-const reqTokenToUser = require("./middleware/reqTokenToUser");
-const mustBeAuthenticated = require("./middleware/mustBeAuthenticated");
-const mustBeAdmin = require("./middleware/mustBeAdmin");
-const mustHaveAccountLinkedToPlex = require("./middleware/mustHaveAccountLinkedToPlex");
+import reqTokenToUser from "./middleware/reqTokenToUser";
+import mustBeAuthenticated from "./middleware/mustBeAuthenticated";
+import mustBeAdmin from "./middleware/mustBeAdmin";
+import mustHaveAccountLinkedToPlex from "./middleware/mustHaveAccountLinkedToPlex";
 
-const listController = require("./controllers/list/listController");
-const tautulli = require("./controllers/user/viewHistory");
-const SettingsController = require("./controllers/user/settings");
-const AuthenticatePlexAccountController = require("./controllers/user/authenticatePlexAccount");
+import listController from "./controllers/list/listController";
+import tautulli from "./controllers/user/viewHistory";
+import SettingsController from "./controllers/user/settings";
+import AuthenticatePlexAccountController from "./controllers/user/authenticatePlexAccount";
+
+const configuration = Configuration.getInstance();
+
+import UserRegisterController from "./controller/user/register";
+import UserLoginController from "./controller/user/login";
+import UserLogoutController from "./controller/user/logout";
+import UserSearchHistoryController from "./controllers/user/searchHistory";
+import UserRequestsController from "./controllers/user/requests";
+
+import SearchMultiController from "./controllers/search/multiSearch";
+import SearchMovieController from "./controllers/search/movieSearch";
+import SearchShowController from "./controllers/search/showSearch";
+import SearchPersonController from "./controllers/search/personSearch";
+
+import MovieCreditsController from "./controllers/movie/credits";
+import MovieReleaseDatesController from "./controllers/movie/releaseDates";
+import MovieInfoController from "./controllers/movie/info";
+
+import ShowCreditsController from "./controllers/show/credits";
+import ShowInfoController from "./controllers/show/info";
+
+import PersonCreditsController from "./controllers/person/credits";
+import PersonInfoController from "./controllers/person/info";
+
+import SeasonedAllController from "./controllers/seasoned/readStrays";
+import SeasonedInfoController from "./controllers/seasoned/strayById";
+import SeasonedVerifyController from "./controllers/seasoned/verifyStray";
+
+import PlexSearchController from "./controllers/plex/search";
+import PlexRequestsAllController from "./controllres/plex/requests/all";
+import PlexRequestsInfo from "./controllers/plex/updateRequested";
+import PlexWatchLinkController from "./controllers/plex/watchDirectLink";
+import PlexHookController from "./controllers/plex/hookDump";
+import PlexSubmitRequestController from "./controllers/plex/submitRequest";
+import PlexRequestInfo from "./controllers/plex/readRequest";
+import PlexSearchRequestController from "./controllers/plex/searchRequest";
+import PlexPlayingController from "./controllers/plex/plexPlaying";
+import PlexSearchMediaController from "./controllres/plex/searchMedia";
+import PlexUpdateRequestedController from "./controllers/plex/updateRequested";
+
+import RequestFetchAllController from "./controllers/request/fetchAllRequests";
+import RequestAllController from "./controllers/plex/fetchRequested";
+import RequestInfoController from "./controllers/request/getRequest";
+import RequestSubmitController from "./controllers/request/requestTmdbId";
+
+import PirateSearchController from "./controllers/pirate/search";
+import PirateAddController from "./controllers/pirate/addMagnet";
+
+import GitDumpController from "./controllres/git/dump";
+import EmojiController from "./controllers/misc/emoji";
 
 // TODO: Have our raven router check if there is a value, if not don't enable raven.
 Raven.config(configuration.get("raven", "DSN")).install();
@@ -65,9 +115,9 @@ router.get("/", (req, res) => {
 /**
  * User
  */
-router.post("/v1/user", require("./controllers/user/register"));
-router.post("/v1/user/login", require("./controllers/user/login"));
-router.post("/v1/user/logout", require("./controllers/user/logout"));
+router.post("/v1/user", UserRegisterController);
+router.post("/v1/user/login", UserLoginController);
+router.post("/v1/user/logout", UserLogoutController);
 
 router.get(
   "/v1/user/settings",
@@ -82,13 +132,9 @@ router.put(
 router.get(
   "/v1/user/search_history",
   mustBeAuthenticated,
-  require("./controllers/user/searchHistory")
+  UserSearchHistoryController
 );
-router.get(
-  "/v1/user/requests",
-  mustBeAuthenticated,
-  require("./controllers/user/requests")
-);
+router.get("/v1/user/requests", mustBeAuthenticated, UserRequestsController);
 
 router.post(
   "/v1/user/link_plex",
@@ -125,111 +171,80 @@ router.get(
 /**
  * Seasoned
  */
-router.get("/v1/seasoned/all", require("./controllers/seasoned/readStrays"));
-router.get(
-  "/v1/seasoned/:strayId",
-  require("./controllers/seasoned/strayById")
-);
-router.post(
-  "/v1/seasoned/verify/:strayId",
-  require("./controllers/seasoned/verifyStray")
-);
+router.get("/v1/seasoned/all", SeasonedAllController);
+router.get("/v1/seasoned/:strayId", SeasonedInfoController);
+router.post("/v1/seasoned/verify/:strayId", SeasonedVerifyController);
 
-router.get("/v2/search/", require("./controllers/search/multiSearch"));
-router.get("/v2/search/movie", require("./controllers/search/movieSearch"));
-router.get("/v2/search/show", require("./controllers/search/showSearch"));
-router.get("/v2/search/person", require("./controllers/search/personSearch"));
+router.get("/v2/search/", SearchMultiController);
+router.get("/v2/search/movie", SearchMovieController);
+router.get("/v2/search/show", SearchShowController);
+router.get("/v2/search/person", SearchPersonController);
 
 router.get("/v2/movie/now_playing", listController.nowPlayingMovies);
 router.get("/v2/movie/popular", listController.popularMovies);
 router.get("/v2/movie/top_rated", listController.topRatedMovies);
 router.get("/v2/movie/upcoming", listController.upcomingMovies);
-router.get("/v2/movie/:id/credits", require("./controllers/movie/credits"));
-router.get(
-  "/v2/movie/:id/release_dates",
-  require("./controllers/movie/releaseDates")
-);
-router.get("/v2/movie/:id", require("./controllers/movie/info"));
-
+router.get("/v2/movie/:id/credits", MovieCreditsController);
+router.get("/v2/movie/:id/release_dates", MovieReleaseDatesController);
+router.get("/v2/movie/:id", MovieInfoController);
 router.get("/v2/show/now_playing", listController.nowPlayingShows);
 router.get("/v2/show/popular", listController.popularShows);
 router.get("/v2/show/top_rated", listController.topRatedShows);
-router.get("/v2/show/:id/credits", require("./controllers/show/credits"));
-router.get("/v2/show/:id", require("./controllers/show/info"));
+router.get("/v2/show/:id/credits", ShowCreditsController);
+router.get("/v2/show/:id", ShowInfoController);
 
-router.get("/v2/person/:id/credits", require("./controllers/person/credits"));
-router.get("/v2/person/:id", require("./controllers/person/info"));
+router.get("/v2/person/:id/credits", PersonCreditsController);
+router.get("/v2/person/:id", PersonInfoController);
 
 /**
  * Plex
  */
-router.get("/v2/plex/search", require("./controllers/plex/search"));
+router.get("/v2/plex/search", PlexSearchController);
 
 /**
  * List
  */
-router.get("/v1/plex/search", require("./controllers/plex/searchMedia"));
-router.get("/v1/plex/playing", require("./controllers/plex/plexPlaying"));
-router.get("/v1/plex/request", require("./controllers/plex/searchRequest"));
-router.get(
-  "/v1/plex/request/:mediaId",
-  require("./controllers/plex/readRequest")
-);
-router.post(
-  "/v1/plex/request/:mediaId",
-  require("./controllers/plex/submitRequest")
-);
-router.post("/v1/plex/hook", require("./controllers/plex/hookDump"));
+router.get("/v1/plex/search", PlexSearchMediaController);
+router.get("/v1/plex/playing", PlexPlayingController);
+router.get("/v1/plex/request", PlexSearchRequestController);
+router.get("/v1/plex/request/:mediaId", PlexRequestInfo);
+router.post("/v1/plex/request/:mediaId", PlexSubmitRequestController);
+router.post("/v1/plex/hook", PlexHookController);
 
-router.get(
-  "/v1/plex/watch-link",
-  mustBeAuthenticated,
-  require("./controllers/plex/watchDirectLink")
-);
+router.get("/v1/plex/watch-link", mustBeAuthenticated, PlexWatchLinkController);
 
 /**
  * Requests
  */
 
-router.get("/v2/request", require("./controllers/request/fetchAllRequests"));
-router.get("/v2/request/:id", require("./controllers/request/getRequest"));
-router.post("/v2/request", require("./controllers/request/requestTmdbId"));
-router.get(
-  "/v1/plex/requests/all",
-  require("./controllers/plex/fetchRequested")
-);
+router.get("/v2/request", RequestFetchAllController);
+router.get("/v2/request/:id", RequestInfoController);
+router.post("/v2/request", RequestSubmitController);
+router.get("/v1/plex/requests/all", RequestAllController);
 router.put(
   "/v1/plex/request/:requestId",
   mustBeAuthenticated,
-  require("./controllers/plex/updateRequested")
+  PlexUpdateRequestedController
 );
 
 /**
  * Pirate
  */
-router.get(
-  "/v1/pirate/search",
-  mustBeAdmin,
-  require("./controllers/pirate/searchTheBay")
-);
-router.post(
-  "/v1/pirate/add",
-  mustBeAdmin,
-  require("./controllers/pirate/addMagnet")
-);
+router.get("/v1/pirate/search", mustBeAdmin, PirateSearchController);
+router.post("/v1/pirate/add", mustBeAdmin, PirateAddController);
 
 /**
  * git
  */
-router.post("/v1/git/dump", require("./controllers/git/dumpHook"));
+router.post("/v1/git/dump", GitDumpController);
 
 /**
  * misc
  */
-router.get("/v1/emoji", require("./controllers/misc/emoji"));
+router.get("/v1/emoji", EmojiController);
 
 // REGISTER OUR ROUTES -------------------------------
 // all of our routes will be prefixed with /api
 app.use("/api", router);
 
-module.exports = app;
+export default app;

--- a/src/webserver/controllers/git/dumpHook.js
+++ b/src/webserver/controllers/git/dumpHook.js
@@ -1,4 +1,4 @@
-import GitRepository from "../../../git/gitRepository";
+import GitRepository from "../../../git/gitRepository.js";
 
 const gitRepository = new GitRepository();
 

--- a/src/webserver/controllers/git/dumpHook.js
+++ b/src/webserver/controllers/git/dumpHook.js
@@ -1,4 +1,4 @@
-const GitRepository = require("../../../git/gitRepository");
+import GitRepository from "../../../git/gitRepository";
 
 const gitRepository = new GitRepository();
 
@@ -9,4 +9,4 @@ function dumpHookController(req, res) {
     .catch(() => res.status(500));
 }
 
-module.exports = dumpHookController;
+export default dumpHookController;

--- a/src/webserver/controllers/list/listController.js
+++ b/src/webserver/controllers/list/listController.js
@@ -1,5 +1,5 @@
-import TMDB from "../../../tmdb/tmdb";
-import Configuration from "../../../config/configuration";
+import TMDB from "../../../tmdb/tmdb.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
@@ -51,17 +51,27 @@ function fetchTmdbList(req, res, listname, type) {
   );
 }
 
-export const nowPlayingMovies = (req, res) =>
+const nowPlayingMovies = (req, res) =>
   fetchTmdbList(req, res, "miscNowPlayingMovies", "movie");
-export const popularMovies = (req, res) =>
+const popularMovies = (req, res) =>
   fetchTmdbList(req, res, "miscPopularMovies", "movie");
-export const topRatedMovies = (req, res) =>
+const topRatedMovies = (req, res) =>
   fetchTmdbList(req, res, "miscTopRatedMovies", "movie");
-export const upcomingMovies = (req, res) =>
+const upcomingMovies = (req, res) =>
   fetchTmdbList(req, res, "miscUpcomingMovies", "movie");
-export const nowPlayingShows = (req, res) =>
+const nowPlayingShows = (req, res) =>
   fetchTmdbList(req, res, "tvOnTheAir", "show");
-export const popularShows = (req, res) =>
+const popularShows = (req, res) =>
   fetchTmdbList(req, res, "miscPopularTvs", "show");
-export const topRatedShows = (req, res) =>
+const topRatedShows = (req, res) =>
   fetchTmdbList(req, res, "miscTopRatedTvs", "show");
+
+export default {
+  nowPlayingMovies,
+  popularMovies,
+  topRatedMovies,
+  upcomingMovies,
+  nowPlayingShows,
+  popularShows,
+  topRatedShows
+};

--- a/src/webserver/controllers/list/listController.js
+++ b/src/webserver/controllers/list/listController.js
@@ -1,6 +1,7 @@
-const configuration = require("../../../config/configuration").getInstance();
-const TMDB = require("../../../tmdb/tmdb");
+import TMDB from "../../../tmdb/tmdb";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 
 // there should be a translate function from query params to
@@ -50,27 +51,17 @@ function fetchTmdbList(req, res, listname, type) {
   );
 }
 
-const nowPlayingMovies = (req, res) =>
+export const nowPlayingMovies = (req, res) =>
   fetchTmdbList(req, res, "miscNowPlayingMovies", "movie");
-const popularMovies = (req, res) =>
+export const popularMovies = (req, res) =>
   fetchTmdbList(req, res, "miscPopularMovies", "movie");
-const topRatedMovies = (req, res) =>
+export const topRatedMovies = (req, res) =>
   fetchTmdbList(req, res, "miscTopRatedMovies", "movie");
-const upcomingMovies = (req, res) =>
+export const upcomingMovies = (req, res) =>
   fetchTmdbList(req, res, "miscUpcomingMovies", "movie");
-const nowPlayingShows = (req, res) =>
+export const nowPlayingShows = (req, res) =>
   fetchTmdbList(req, res, "tvOnTheAir", "show");
-const popularShows = (req, res) =>
+export const popularShows = (req, res) =>
   fetchTmdbList(req, res, "miscPopularTvs", "show");
-const topRatedShows = (req, res) =>
+export const topRatedShows = (req, res) =>
   fetchTmdbList(req, res, "miscTopRatedTvs", "show");
-
-module.exports = {
-  nowPlayingMovies,
-  popularMovies,
-  topRatedMovies,
-  upcomingMovies,
-  nowPlayingShows,
-  popularShows,
-  topRatedShows
-};

--- a/src/webserver/controllers/misc/emoji.js
+++ b/src/webserver/controllers/misc/emoji.js
@@ -16,12 +16,10 @@ const randomEmoji = () => {
  * @param {Response} res
  * @returns {Callback}
  */
-function emojiController(req, res) {
+export default function emojiController(req, res) {
   res.send({
     success: true,
     emoji: randomEmoji(),
     message: "Happy emoji-ing! 🌝"
   });
 }
-
-module.exports = emojiController;

--- a/src/webserver/controllers/movie/credits.js
+++ b/src/webserver/controllers/movie/credits.js
@@ -1,5 +1,5 @@
-import TMDB from "../../../tmdb/tmdb";
-import Configuration from "../../../config/configuration";
+import TMDB from "../../../tmdb/tmdb.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));

--- a/src/webserver/controllers/movie/credits.js
+++ b/src/webserver/controllers/movie/credits.js
@@ -1,6 +1,7 @@
-const configuration = require("../../../config/configuration").getInstance();
-const TMDB = require("../../../tmdb/tmdb");
+import TMDB from "../../../tmdb/tmdb";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 
 const movieCreditsController = (req, res) => {
@@ -19,4 +20,4 @@ const movieCreditsController = (req, res) => {
     });
 };
 
-module.exports = movieCreditsController;
+export default movieCreditsController;

--- a/src/webserver/controllers/movie/info.js
+++ b/src/webserver/controllers/movie/info.js
@@ -1,7 +1,8 @@
-const configuration = require("../../../config/configuration").getInstance();
-const TMDB = require("../../../tmdb/tmdb");
-const Plex = require("../../../plex/plex");
+import TMDB from "../../../tmdb/tmdb";
+import Plex from "../../../plex/plex";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 const plex = new Plex(configuration.get("plex", "ip"));
 
@@ -52,4 +53,4 @@ async function movieInfoController(req, res) {
   }
 }
 
-module.exports = movieInfoController;
+export default movieInfoController;

--- a/src/webserver/controllers/movie/info.js
+++ b/src/webserver/controllers/movie/info.js
@@ -1,6 +1,6 @@
-import TMDB from "../../../tmdb/tmdb";
-import Plex from "../../../plex/plex";
-import Configuration from "../../../config/configuration";
+import TMDB from "../../../tmdb/tmdb.js";
+import Plex from "../../../plex/plex.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));

--- a/src/webserver/controllers/movie/releaseDates.js
+++ b/src/webserver/controllers/movie/releaseDates.js
@@ -1,5 +1,5 @@
-import TMDB from "../../../tmdb/tmdb";
-import Configuration from "../../../config/configuration";
+import TMDB from "../../../tmdb/tmdb.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));

--- a/src/webserver/controllers/movie/releaseDates.js
+++ b/src/webserver/controllers/movie/releaseDates.js
@@ -1,6 +1,7 @@
-const configuration = require("../../../config/configuration").getInstance();
-const TMDB = require("../../../tmdb/tmdb");
+import TMDB from "../../../tmdb/tmdb";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 
 const movieReleaseDatesController = (req, res) => {
@@ -19,4 +20,4 @@ const movieReleaseDatesController = (req, res) => {
     });
 };
 
-module.exports = movieReleaseDatesController;
+export default movieReleaseDatesController;

--- a/src/webserver/controllers/person/credits.js
+++ b/src/webserver/controllers/person/credits.js
@@ -1,7 +1,8 @@
-const configuration = require("../../../config/configuration").getInstance();
-const TMDB = require("../../../tmdb/tmdb");
+import TMDB from "../../../tmdb/tmdb";
+import Configuration from "../../../config/configuration";
 
-const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
+const configuration = Configuration.getInstance();
+const tmdb = new TMDB(Configuration.get("tmdb", "apiKey"));
 
 const personCreditsController = (req, res) => {
   const personId = req.params.id;
@@ -19,4 +20,4 @@ const personCreditsController = (req, res) => {
     });
 };
 
-module.exports = personCreditsController;
+export default personCreditsController;

--- a/src/webserver/controllers/person/credits.js
+++ b/src/webserver/controllers/person/credits.js
@@ -1,8 +1,8 @@
-import TMDB from "../../../tmdb/tmdb";
-import Configuration from "../../../config/configuration";
+import TMDB from "../../../tmdb/tmdb.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
-const tmdb = new TMDB(Configuration.get("tmdb", "apiKey"));
+const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 
 const personCreditsController = (req, res) => {
   const personId = req.params.id;

--- a/src/webserver/controllers/person/info.js
+++ b/src/webserver/controllers/person/info.js
@@ -1,6 +1,7 @@
-const configuration = require("../../../config/configuration").getInstance();
-const TMDB = require("../../../tmdb/tmdb");
+import TMDB from "../../../tmdb/tmdb";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 
 /**
@@ -36,4 +37,4 @@ async function personInfoController(req, res) {
   }
 }
 
-module.exports = personInfoController;
+export default personInfoController;

--- a/src/webserver/controllers/person/info.js
+++ b/src/webserver/controllers/person/info.js
@@ -1,5 +1,5 @@
-import TMDB from "../../../tmdb/tmdb";
-import Configuration from "../../../config/configuration";
+import TMDB from "../../../tmdb/tmdb.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));

--- a/src/webserver/controllers/pirate/addMagnet.js
+++ b/src/webserver/controllers/pirate/addMagnet.js
@@ -5,7 +5,7 @@
  * @Last Modified time: 2017-10-21 15:32:43
  */
 
-const PirateRepository = require("../../../pirate/pirateRepository");
+import PirateRepository from "../../../pirate/pirateRepository";
 
 function addMagnet(req, res) {
   const { magnet, name } = req.body;
@@ -18,4 +18,4 @@ function addMagnet(req, res) {
     });
 }
 
-module.exports = addMagnet;
+export default addMagnet;

--- a/src/webserver/controllers/pirate/addMagnet.js
+++ b/src/webserver/controllers/pirate/addMagnet.js
@@ -5,13 +5,13 @@
  * @Last Modified time: 2017-10-21 15:32:43
  */
 
-import PirateRepository from "../../../pirate/pirateRepository";
+import { AddMagnet } from "../../../pirate/pirateRepository.js";
 
 function addMagnet(req, res) {
   const { magnet, name } = req.body;
   const tmdbId = req.body?.tmdb_id;
 
-  PirateRepository.AddMagnet(magnet, name, tmdbId)
+  AddMagnet(magnet, name, tmdbId)
     .then(result => res.send(result))
     .catch(error => {
       res.status(500).send({ success: false, message: error.message });

--- a/src/webserver/controllers/pirate/searchTheBay.js
+++ b/src/webserver/controllers/pirate/searchTheBay.js
@@ -5,7 +5,7 @@
  * @Last Modified time: 2018-02-26 19:56:32
  */
 
-import PirateRepository from "../../../pirate/pirateRepository";
+import { SearchPiratebay } from "../../../pirate/pirateRepository.js";
 // const pirateRepository = new PirateRepository();
 
 /**
@@ -17,7 +17,7 @@ import PirateRepository from "../../../pirate/pirateRepository";
 function updateRequested(req, res) {
   const { query, page, type } = req.query;
 
-  PirateRepository.SearchPiratebay(query, page, type)
+  SearchPiratebay(query, page, type)
     .then(result => {
       res.send({ success: true, results: result });
     })

--- a/src/webserver/controllers/pirate/searchTheBay.js
+++ b/src/webserver/controllers/pirate/searchTheBay.js
@@ -5,7 +5,7 @@
  * @Last Modified time: 2018-02-26 19:56:32
  */
 
-const PirateRepository = require("../../../pirate/pirateRepository");
+import PirateRepository from "../../../pirate/pirateRepository";
 // const pirateRepository = new PirateRepository();
 
 /**
@@ -26,4 +26,4 @@ function updateRequested(req, res) {
     });
 }
 
-module.exports = updateRequested;
+export default updateRequested;

--- a/src/webserver/controllers/plex/fetchRequested.js
+++ b/src/webserver/controllers/plex/fetchRequested.js
@@ -1,4 +1,4 @@
-import RequestRepository from "../../../plex/requestRepository";
+import RequestRepository from "../../../plex/requestRepository.js";
 
 const requestRepository = new RequestRepository();
 

--- a/src/webserver/controllers/plex/fetchRequested.js
+++ b/src/webserver/controllers/plex/fetchRequested.js
@@ -1,4 +1,4 @@
-const RequestRepository = require("../../../plex/requestRepository");
+import RequestRepository from "../../../plex/requestRepository";
 
 const requestRepository = new RequestRepository();
 
@@ -26,4 +26,4 @@ function fetchRequestedController(req, res) {
     });
 }
 
-module.exports = fetchRequestedController;
+export default fetchRequestedController;

--- a/src/webserver/controllers/plex/hookDump.js
+++ b/src/webserver/controllers/plex/hookDump.js
@@ -5,4 +5,4 @@ function hookDumpController(req, res) {
   res.status(200);
 }
 
-module.exports = hookDumpController;
+export default hookDumpController;

--- a/src/webserver/controllers/plex/plexPlaying.js
+++ b/src/webserver/controllers/plex/plexPlaying.js
@@ -1,5 +1,5 @@
-import PlexRepository from "../../../plex/plexRepository";
-import Configuration from "../../../config/configuration";
+import PlexRepository from "../../../plex/plexRepository.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 
@@ -19,4 +19,4 @@ function playingController(req, res) {
     });
 }
 
-module.exports = playingController;
+export default playingController;

--- a/src/webserver/controllers/plex/plexPlaying.js
+++ b/src/webserver/controllers/plex/plexPlaying.js
@@ -1,5 +1,7 @@
-const PlexRepository = require("../../../plex/plexRepository");
-const configuration = require("../../../config/configuration").getInstance();
+import PlexRepository from "../../../plex/plexRepository";
+import Configuration from "../../../config/configuration";
+
+const configuration = Configuration.getInstance();
 
 const plexRepository = new PlexRepository(
   configuration.get("plex", "ip"),

--- a/src/webserver/controllers/plex/readRequest.js
+++ b/src/webserver/controllers/plex/readRequest.js
@@ -1,4 +1,4 @@
-const RequestRepository = require("../../../plex/requestRepository");
+import RequestRepository from "../../../plex/requestRepository";
 
 const requestRepository = new RequestRepository();
 
@@ -21,4 +21,4 @@ function readRequestController(req, res) {
     });
 }
 
-module.exports = readRequestController;
+export default readRequestController;

--- a/src/webserver/controllers/plex/readRequest.js
+++ b/src/webserver/controllers/plex/readRequest.js
@@ -1,4 +1,4 @@
-import RequestRepository from "../../../plex/requestRepository";
+import RequestRepository from "../../../plex/requestRepository.js";
 
 const requestRepository = new RequestRepository();
 

--- a/src/webserver/controllers/plex/search.js
+++ b/src/webserver/controllers/plex/search.js
@@ -1,5 +1,7 @@
-const configuration = require("../../../config/configuration").getInstance();
-const Plex = require("../../../plex/plex");
+import Plex from "../../../plex/plex";
+import Configuration from "../../../config/configuration";
+
+const configuration = Configuration.getInstance();
 
 const plex = new Plex(configuration.get("plex", "ip"));
 
@@ -28,4 +30,4 @@ function searchPlexController(req, res) {
     });
 }
 
-module.exports = searchPlexController;
+export default searchPlexController;

--- a/src/webserver/controllers/plex/search.js
+++ b/src/webserver/controllers/plex/search.js
@@ -1,5 +1,5 @@
-import Plex from "../../../plex/plex";
-import Configuration from "../../../config/configuration";
+import Plex from "../../../plex/plex.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 

--- a/src/webserver/controllers/plex/searchMedia.js
+++ b/src/webserver/controllers/plex/searchMedia.js
@@ -1,5 +1,5 @@
-import PlexRepository from "../../../plex/plexRepository";
-import Configuration from "../../../config/configuration";
+import PlexRepository from "../../../plex/plexRepository.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 

--- a/src/webserver/controllers/plex/searchMedia.js
+++ b/src/webserver/controllers/plex/searchMedia.js
@@ -1,5 +1,7 @@
-const PlexRepository = require("../../../plex/plexRepository");
-const configuration = require("../../../config/configuration").getInstance();
+import PlexRepository from "../../../plex/plexRepository";
+import Configuration from "../../../config/configuration";
+
+const configuration = Configuration.getInstance();
 
 const plexRepository = new PlexRepository(
   configuration.get("plex", "ip"),
@@ -33,4 +35,4 @@ function searchMediaController(req, res) {
     });
 }
 
-module.exports = searchMediaController;
+export default searchMediaController;

--- a/src/webserver/controllers/plex/searchRequest.js
+++ b/src/webserver/controllers/plex/searchRequest.js
@@ -1,6 +1,6 @@
-const SearchHistory = require("../../../searchHistory/searchHistory");
-const Cache = require("../../../tmdb/cache");
-const RequestRepository = require("../../../plex/requestRepository");
+import SearchHistory from "../../../searchHistory/searchHistory";
+import Cache from "../../../tmdb/cache";
+import RequestRepository from "../../../plex/requestRepository";
 
 const cache = new Cache();
 const requestRepository = new RequestRepository(cache);
@@ -21,4 +21,4 @@ function searchRequestController(req, res) {
     });
 }
 
-module.exports = searchRequestController;
+export default searchRequestController;

--- a/src/webserver/controllers/plex/searchRequest.js
+++ b/src/webserver/controllers/plex/searchRequest.js
@@ -1,6 +1,6 @@
-import SearchHistory from "../../../searchHistory/searchHistory";
-import Cache from "../../../tmdb/cache";
-import RequestRepository from "../../../plex/requestRepository";
+import SearchHistory from "../../../searchHistory/searchHistory.js";
+import Cache from "../../../tmdb/cache.js";
+import RequestRepository from "../../../plex/requestRepository.js";
 
 const cache = new Cache();
 const requestRepository = new RequestRepository(cache);

--- a/src/webserver/controllers/plex/submitRequest.js
+++ b/src/webserver/controllers/plex/submitRequest.js
@@ -1,6 +1,6 @@
-import RequestRepository from "../../../request/request";
-import TMDB from "../../../tmdb/tmdb";
-import Configuration from "../../../config/configuration";
+import RequestRepository from "../../../request/request.js";
+import TMDB from "../../../tmdb/tmdb.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));

--- a/src/webserver/controllers/plex/submitRequest.js
+++ b/src/webserver/controllers/plex/submitRequest.js
@@ -1,7 +1,8 @@
-const configuration = require("../../../config/configuration").getInstance();
-const RequestRepository = require("../../../request/request");
-const TMDB = require("../../../tmdb/tmdb");
+import RequestRepository from "../../../request/request";
+import TMDB from "../../../tmdb/tmdb";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 const request = new RequestRepository();
 
@@ -57,4 +58,4 @@ function submitRequestController(req, res) {
     );
 }
 
-module.exports = submitRequestController;
+export default submitRequestController;

--- a/src/webserver/controllers/plex/updateRequested.js
+++ b/src/webserver/controllers/plex/updateRequested.js
@@ -1,4 +1,4 @@
-const RequestRepository = require("../../../plex/requestRepository");
+import RequestRepository from "../../../plex/requestRepository";
 
 const requestRepository = new RequestRepository();
 
@@ -23,4 +23,4 @@ function updateRequested(req, res) {
     });
 }
 
-module.exports = updateRequested;
+export default updateRequested;

--- a/src/webserver/controllers/plex/updateRequested.js
+++ b/src/webserver/controllers/plex/updateRequested.js
@@ -1,4 +1,4 @@
-import RequestRepository from "../../../plex/requestRepository";
+import RequestRepository from "../../../plex/requestRepository.js";
 
 const requestRepository = new RequestRepository();
 

--- a/src/webserver/controllers/plex/watchDirectLink.js
+++ b/src/webserver/controllers/plex/watchDirectLink.js
@@ -1,5 +1,5 @@
-import Plex from "../../../plex/plex";
-import Configuration from "../../../config/configuration";
+import Plex from "../../../plex/plex.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const plex = new Plex(configuration.get("plex", "ip"));

--- a/src/webserver/controllers/plex/watchDirectLink.js
+++ b/src/webserver/controllers/plex/watchDirectLink.js
@@ -1,6 +1,7 @@
-const configuration = require("../../../config/configuration").getInstance();
-const Plex = require("../../../plex/plex");
+import Plex from "../../../plex/plex";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const plex = new Plex(configuration.get("plex", "ip"));
 
 /**
@@ -25,4 +26,4 @@ function watchDirectLink(req, res) {
     });
 }
 
-module.exports = watchDirectLink;
+export default watchDirectLink;

--- a/src/webserver/controllers/request/fetchAllRequests.js
+++ b/src/webserver/controllers/request/fetchAllRequests.js
@@ -1,4 +1,4 @@
-import RequestRepository from "../../../request/request";
+import RequestRepository from "../../../request/request.js";
 
 const request = new RequestRepository();
 

--- a/src/webserver/controllers/request/fetchAllRequests.js
+++ b/src/webserver/controllers/request/fetchAllRequests.js
@@ -1,4 +1,4 @@
-const RequestRepository = require("../../../request/request");
+import RequestRepository from "../../../request/request";
 
 const request = new RequestRepository();
 
@@ -24,4 +24,4 @@ function fetchAllRequests(req, res) {
     });
 }
 
-module.exports = fetchAllRequests;
+export default fetchAllRequests;

--- a/src/webserver/controllers/request/getRequest.js
+++ b/src/webserver/controllers/request/getRequest.js
@@ -1,4 +1,4 @@
-import RequestRepository from "../../../request/request";
+import RequestRepository from "../../../request/request.js";
 
 const request = new RequestRepository();
 

--- a/src/webserver/controllers/request/getRequest.js
+++ b/src/webserver/controllers/request/getRequest.js
@@ -1,4 +1,4 @@
-const RequestRepository = require("../../../request/request");
+import RequestRepository from "../../../request/request";
 
 const request = new RequestRepository();
 
@@ -37,4 +37,4 @@ function fetchAllRequests(req, res) {
     });
 }
 
-module.exports = fetchAllRequests;
+export default fetchAllRequests;

--- a/src/webserver/controllers/request/requestTmdbId.js
+++ b/src/webserver/controllers/request/requestTmdbId.js
@@ -1,6 +1,6 @@
-import TMDB from "../../../tmdb/tmdb";
-import RequestRepository from "../../../request/request";
-import Configuration from "../../../config/configuration";
+import TMDB from "../../../tmdb/tmdb.js";
+import RequestRepository from "../../../request/request.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));

--- a/src/webserver/controllers/request/requestTmdbId.js
+++ b/src/webserver/controllers/request/requestTmdbId.js
@@ -1,11 +1,11 @@
 import TMDB from "../../../tmdb/tmdb.js";
 import RequestRepository from "../../../request/request.js";
 import Configuration from "../../../config/configuration.js";
+// import sendSMS from "../../../notifications/sms.js";
 
 const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 const request = new RequestRepository();
-// const { sendSMS } = require("src/notifications/sms");
 
 const tmdbMovieInfo = id => {
   return tmdb.movieInfo(id);

--- a/src/webserver/controllers/request/requestTmdbId.js
+++ b/src/webserver/controllers/request/requestTmdbId.js
@@ -1,7 +1,8 @@
-const configuration = require("../../../config/configuration").getInstance();
-const TMDB = require("../../../tmdb/tmdb");
-const RequestRepository = require("../../../request/request");
+import TMDB from "../../../tmdb/tmdb";
+import RequestRepository from "../../../request/request";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 const request = new RequestRepository();
 // const { sendSMS } = require("src/notifications/sms");
@@ -65,4 +66,4 @@ function requestTmdbIdController(req, res) {
     });
 }
 
-module.exports = requestTmdbIdController;
+export default requestTmdbIdController;

--- a/src/webserver/controllers/search/movieSearch.js
+++ b/src/webserver/controllers/search/movieSearch.js
@@ -1,7 +1,8 @@
-const configuration = require("../../../config/configuration").getInstance();
-const TMDB = require("../../../tmdb/tmdb");
-const SearchHistory = require("../../../searchHistory/searchHistory");
+import TMDB from "../../../tmdb/tmdb";
+import SearchHistory from "../../../searchHistory/searchHistory";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 const searchHistory = new SearchHistory();
 
@@ -33,4 +34,4 @@ function movieSearchController(req, res) {
     });
 }
 
-module.exports = movieSearchController;
+export default movieSearchController;

--- a/src/webserver/controllers/search/movieSearch.js
+++ b/src/webserver/controllers/search/movieSearch.js
@@ -1,6 +1,6 @@
-import TMDB from "../../../tmdb/tmdb";
-import SearchHistory from "../../../searchHistory/searchHistory";
-import Configuration from "../../../config/configuration";
+import TMDB from "../../../tmdb/tmdb.js";
+import SearchHistory from "../../../searchHistory/searchHistory.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));

--- a/src/webserver/controllers/search/multiSearch.js
+++ b/src/webserver/controllers/search/multiSearch.js
@@ -1,6 +1,6 @@
-import TMDB from "../../../tmdb/tmdb";
-import SearchHistory from "../../../searchHistory/searchHistory";
-import Configuration from "../../../config/configuration";
+import TMDB from "../../../tmdb/tmdb.js";
+import SearchHistory from "../../../searchHistory/searchHistory.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));

--- a/src/webserver/controllers/search/multiSearch.js
+++ b/src/webserver/controllers/search/multiSearch.js
@@ -1,7 +1,8 @@
-const configuration = require("../../../config/configuration").getInstance();
-const TMDB = require("../../../tmdb/tmdb");
-const SearchHistory = require("../../../searchHistory/searchHistory");
+import TMDB from "../../../tmdb/tmdb";
+import SearchHistory from "../../../searchHistory/searchHistory";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 const searchHistory = new SearchHistory();
 
@@ -33,4 +34,4 @@ function multiSearchController(req, res) {
     });
 }
 
-module.exports = multiSearchController;
+export default multiSearchController;

--- a/src/webserver/controllers/search/personSearch.js
+++ b/src/webserver/controllers/search/personSearch.js
@@ -1,6 +1,6 @@
-import TMDB from "../../../tmdb/tmdb";
-import SearchHistory from "../../../searchHistory/searchHistory";
-import Configuration from "../../../config/configuration";
+import TMDB from "../../../tmdb/tmdb.js";
+import SearchHistory from "../../../searchHistory/searchHistory.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));

--- a/src/webserver/controllers/search/personSearch.js
+++ b/src/webserver/controllers/search/personSearch.js
@@ -1,7 +1,8 @@
-const configuration = require("../../../config/configuration").getInstance();
-const TMDB = require("../../../tmdb/tmdb");
-const SearchHistory = require("../../../searchHistory/searchHistory");
+import TMDB from "../../../tmdb/tmdb";
+import SearchHistory from "../../../searchHistory/searchHistory";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 const searchHistory = new SearchHistory();
 
@@ -33,4 +34,4 @@ function personSearchController(req, res) {
     });
 }
 
-module.exports = personSearchController;
+export default personSearchController;

--- a/src/webserver/controllers/search/showSearch.js
+++ b/src/webserver/controllers/search/showSearch.js
@@ -1,7 +1,8 @@
-const SearchHistory = require("../../../searchHistory/searchHistory");
-const configuration = require("../../../config/configuration").getInstance();
-const TMDB = require("../../../tmdb/tmdb");
+import SearchHistory from "../../../searchHistory/searchHistory";
+import TMDB from "../../../tmdb/tmdb";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 const searchHistory = new SearchHistory();
 
@@ -35,4 +36,4 @@ function showSearchController(req, res) {
     });
 }
 
-module.exports = showSearchController;
+export default showSearchController;

--- a/src/webserver/controllers/search/showSearch.js
+++ b/src/webserver/controllers/search/showSearch.js
@@ -1,6 +1,6 @@
-import SearchHistory from "../../../searchHistory/searchHistory";
-import TMDB from "../../../tmdb/tmdb";
-import Configuration from "../../../config/configuration";
+import TMDB from "../../../tmdb/tmdb.js";
+import SearchHistory from "../../../searchHistory/searchHistory.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));

--- a/src/webserver/controllers/seasoned/readStrays.js
+++ b/src/webserver/controllers/seasoned/readStrays.js
@@ -1,4 +1,4 @@
-import StrayRepository from "../../../seasoned/strayRepository";
+import StrayRepository from "../../../seasoned/strayRepository.js";
 
 const strayRepository = new StrayRepository();
 

--- a/src/webserver/controllers/seasoned/readStrays.js
+++ b/src/webserver/controllers/seasoned/readStrays.js
@@ -1,4 +1,4 @@
-const StrayRepository = require("../../../seasoned/strayRepository");
+import StrayRepository from "../../../seasoned/strayRepository";
 
 const strayRepository = new StrayRepository();
 
@@ -14,4 +14,4 @@ function readStraysController(req, res) {
     });
 }
 
-module.exports = readStraysController;
+export default readStraysController;

--- a/src/webserver/controllers/seasoned/strayById.js
+++ b/src/webserver/controllers/seasoned/strayById.js
@@ -1,4 +1,4 @@
-import StrayRepository from "../../../seasoned/strayRepository";
+import StrayRepository from "../../../seasoned/strayRepository.js";
 
 const strayRepository = new StrayRepository();
 

--- a/src/webserver/controllers/seasoned/strayById.js
+++ b/src/webserver/controllers/seasoned/strayById.js
@@ -1,4 +1,4 @@
-const StrayRepository = require("../../../seasoned/strayRepository");
+import StrayRepository from "../../../seasoned/strayRepository";
 
 const strayRepository = new StrayRepository();
 
@@ -15,4 +15,4 @@ function strayByIdController(req, res) {
     });
 }
 
-module.exports = strayByIdController;
+export default strayByIdController;

--- a/src/webserver/controllers/seasoned/verifyStray.js
+++ b/src/webserver/controllers/seasoned/verifyStray.js
@@ -1,4 +1,4 @@
-import StrayRepository from "../../../seasoned/strayRepository";
+import StrayRepository from "../../../seasoned/strayRepository.js";
 
 const strayRepository = new StrayRepository();
 

--- a/src/webserver/controllers/seasoned/verifyStray.js
+++ b/src/webserver/controllers/seasoned/verifyStray.js
@@ -1,4 +1,4 @@
-const StrayRepository = require("../../../seasoned/strayRepository");
+import StrayRepository from "../../../seasoned/strayRepository";
 
 const strayRepository = new StrayRepository();
 
@@ -15,4 +15,4 @@ function verifyStrayController(req, res) {
     });
 }
 
-module.exports = verifyStrayController;
+export default verifyStrayController;

--- a/src/webserver/controllers/show/credits.js
+++ b/src/webserver/controllers/show/credits.js
@@ -1,6 +1,7 @@
-const configuration = require("../../../config/configuration").getInstance();
-const TMDB = require("../../../tmdb/tmdb");
+import TMDB from "../../../tmdb/tmdb";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 
 const showCreditsController = (req, res) => {
@@ -19,4 +20,4 @@ const showCreditsController = (req, res) => {
     });
 };
 
-module.exports = showCreditsController;
+export default showCreditsController;

--- a/src/webserver/controllers/show/credits.js
+++ b/src/webserver/controllers/show/credits.js
@@ -1,5 +1,5 @@
-import TMDB from "../../../tmdb/tmdb";
-import Configuration from "../../../config/configuration";
+import TMDB from "../../../tmdb/tmdb.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));

--- a/src/webserver/controllers/show/info.js
+++ b/src/webserver/controllers/show/info.js
@@ -1,6 +1,6 @@
-import TMDB from "../../../tmdb/tmdb";
-import Plex from "../../../plex/plex";
-import Configuration from "../../../config/configuration";
+import TMDB from "../../../tmdb/tmdb.js";
+import Plex from "../../../plex/plex.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));

--- a/src/webserver/controllers/show/info.js
+++ b/src/webserver/controllers/show/info.js
@@ -1,7 +1,8 @@
-const configuration = require("../../../config/configuration").getInstance();
-const TMDB = require("../../../tmdb/tmdb");
-const Plex = require("../../../plex/plex");
+import TMDB from "../../../tmdb/tmdb";
+import Plex from "../../../plex/plex";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const tmdb = new TMDB(configuration.get("tmdb", "apiKey"));
 const plex = new Plex(configuration.get("plex", "ip"));
 
@@ -47,4 +48,4 @@ async function showInfoController(req, res) {
   }
 }
 
-module.exports = showInfoController;
+export default showInfoController;

--- a/src/webserver/controllers/user/authenticatePlexAccount.js
+++ b/src/webserver/controllers/user/authenticatePlexAccount.js
@@ -1,5 +1,5 @@
-const FormData = require("form-data");
-const UserRepository = require("../../../user/userRepository");
+import FormData from "form-data";
+import UserRepository from "../../../user/userRepository";
 
 const userRepository = new UserRepository();
 
@@ -67,7 +67,7 @@ function plexAuthenticate(username, password) {
   return fetch(url, options).then(resp => handleResponse(resp));
 }
 
-function link(req, res) {
+export function link(req, res) {
   const user = req.loggedInUser;
   const { username, password } = req.body;
 
@@ -80,10 +80,19 @@ function link(req, res) {
           "Successfully authenticated and linked plex account with seasoned request."
       })
     )
-    .catch(error => handleError(error, res));
+    .catch(error =>
+      res.status(error?.statusCode || 500).send({
+        message:
+          error?.message ||
+          "Unexptected error occured while linking plex account",
+        success: error?.success || false,
+        source: error?.source,
+        errorResponse: error?.errorResponse
+      })
+    );
 }
 
-function unlink(req, res) {
+export function unlink(req, res) {
   const username = req.loggedInUser ? req.loggedInUser.username : null;
 
   return userRepository
@@ -94,10 +103,14 @@ function unlink(req, res) {
         message: "Successfully unlinked plex account from seasoned request."
       })
     )
-    .catch(error => handleError(error, res));
+    .catch(error =>
+      res.status(error?.statusCode || 500).send({
+        message:
+          error?.message ||
+          "Unexptected error occured while unlinking plex account",
+        success: error?.success || false,
+        source: error?.source,
+        errorResponse: error?.errorResponse
+      })
+    );
 }
-
-module.exports = {
-  link,
-  unlink
-};

--- a/src/webserver/controllers/user/authenticatePlexAccount.js
+++ b/src/webserver/controllers/user/authenticatePlexAccount.js
@@ -1,5 +1,5 @@
 import FormData from "form-data";
-import UserRepository from "../../../user/userRepository";
+import UserRepository from "../../../user/userRepository.js";
 
 const userRepository = new UserRepository();
 
@@ -61,7 +61,7 @@ function plexAuthenticate(username, password) {
   return fetch(url, options).then(resp => handleResponse(resp));
 }
 
-export function link(req, res) {
+function link(req, res) {
   const user = req.loggedInUser;
   const { username, password } = req.body;
 
@@ -86,7 +86,7 @@ export function link(req, res) {
     );
 }
 
-export function unlink(req, res) {
+function unlink(req, res) {
   const username = req.loggedInUser ? req.loggedInUser.username : null;
 
   return userRepository
@@ -108,3 +108,5 @@ export function unlink(req, res) {
       })
     );
 }
+
+export default { link, unlink };

--- a/src/webserver/controllers/user/login.js
+++ b/src/webserver/controllers/user/login.js
@@ -1,8 +1,8 @@
-import User from "../../../user/user";
-import Token from "../../../user/token";
-import UserSecurity from "../../../user/userSecurity";
-import UserRepository from "../../../user/userRepository";
-import Configuration from "../../../config/configuration";
+import User from "../../../user/user.js";
+import Token from "../../../user/token.js";
+import UserSecurity from "../../../user/userSecurity.js";
+import UserRepository from "../../../user/userRepository.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const secret = configuration.get("authentication", "secret");

--- a/src/webserver/controllers/user/login.js
+++ b/src/webserver/controllers/user/login.js
@@ -1,9 +1,10 @@
-const User = require("../../../user/user");
-const Token = require("../../../user/token");
-const UserSecurity = require("../../../user/userSecurity");
-const UserRepository = require("../../../user/userRepository");
-const configuration = require("../../../config/configuration").getInstance();
+import User from "../../../user/user";
+import Token from "../../../user/token";
+import UserSecurity from "../../../user/userSecurity";
+import UserRepository from "../../../user/userRepository";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const secret = configuration.get("authentication", "secret");
 const userSecurity = new UserSecurity();
 const userRepository = new UserRepository();
@@ -54,4 +55,4 @@ async function loginController(req, res) {
   }
 }
 
-module.exports = loginController;
+export default loginController;

--- a/src/webserver/controllers/user/logout.js
+++ b/src/webserver/controllers/user/logout.js
@@ -13,4 +13,4 @@ async function logoutController(req, res) {
   });
 }
 
-module.exports = logoutController;
+export default logoutController;

--- a/src/webserver/controllers/user/register.js
+++ b/src/webserver/controllers/user/register.js
@@ -1,7 +1,7 @@
-import User from "../../../user/user";
-import Token from "../../../user/token";
-import UserSecurity from "../../../user/userSecurity";
-import Configuration from "../../../config/configuration";
+import User from "../../../user/user.js";
+import Token from "../../../user/token.js";
+import UserSecurity from "../../../user/userSecurity.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const secret = configuration.get("authentication", "secret");

--- a/src/webserver/controllers/user/register.js
+++ b/src/webserver/controllers/user/register.js
@@ -1,8 +1,9 @@
-const User = require("../../../user/user");
-const Token = require("../../../user/token");
-const UserSecurity = require("../../../user/userSecurity");
-const configuration = require("../../../config/configuration").getInstance();
+import User from "../../../user/user";
+import Token from "../../../user/token";
+import UserSecurity from "../../../user/userSecurity";
+import Configuration from "../../../config/configuration";
 
+const configuration = Configuration.getInstance();
 const secret = configuration.get("authentication", "secret");
 const userSecurity = new UserSecurity();
 
@@ -42,4 +43,4 @@ function registerController(req, res) {
     });
 }
 
-module.exports = registerController;
+export default registerController;

--- a/src/webserver/controllers/user/requests.js
+++ b/src/webserver/controllers/user/requests.js
@@ -1,4 +1,4 @@
-import RequestRepository from "../../../plex/requestRepository";
+import RequestRepository from "../../../plex/requestRepository.js";
 
 const requestRepository = new RequestRepository();
 

--- a/src/webserver/controllers/user/requests.js
+++ b/src/webserver/controllers/user/requests.js
@@ -1,4 +1,4 @@
-const RequestRepository = require("../../../plex/requestRepository");
+import RequestRepository from "../../../plex/requestRepository";
 
 const requestRepository = new RequestRepository();
 
@@ -25,4 +25,4 @@ function requestsController(req, res) {
     });
 }
 
-module.exports = requestsController;
+export default requestsController;

--- a/src/webserver/controllers/user/searchHistory.js
+++ b/src/webserver/controllers/user/searchHistory.js
@@ -1,4 +1,4 @@
-import SearchHistory from "../../../searchHistory/searchHistory";
+import SearchHistory from "../../../searchHistory/searchHistory.js";
 
 const searchHistory = new SearchHistory();
 

--- a/src/webserver/controllers/user/searchHistory.js
+++ b/src/webserver/controllers/user/searchHistory.js
@@ -1,4 +1,4 @@
-const SearchHistory = require("../../../searchHistory/searchHistory");
+import SearchHistory from "../../../searchHistory/searchHistory";
 
 const searchHistory = new SearchHistory();
 
@@ -21,4 +21,4 @@ function historyController(req, res) {
     });
 }
 
-module.exports = historyController;
+export default historyController;

--- a/src/webserver/controllers/user/settings.js
+++ b/src/webserver/controllers/user/settings.js
@@ -1,4 +1,4 @@
-import UserRepository from "../../../user/userRepository";
+import UserRepository from "../../../user/userRepository.js";
 
 const userRepository = new UserRepository();
 /**

--- a/src/webserver/controllers/user/settings.js
+++ b/src/webserver/controllers/user/settings.js
@@ -1,4 +1,4 @@
-const UserRepository = require("../../../user/userRepository");
+import UserRepository from "../../../user/userRepository";
 
 const userRepository = new UserRepository();
 /**
@@ -7,7 +7,7 @@ const userRepository = new UserRepository();
  * @param {Response} res
  * @returns {Callback}
  */
-const getSettingsController = (req, res) => {
+export function getSettingsController(req, res) {
   const username = req.loggedInUser ? req.loggedInUser.username : null;
 
   userRepository
@@ -18,9 +18,9 @@ const getSettingsController = (req, res) => {
     .catch(error => {
       res.status(404).send({ success: false, message: error.message });
     });
-};
+}
 
-const updateSettingsController = (req, res) => {
+export function updateSettingsController(req, res) {
   const username = req.loggedInUser ? req.loggedInUser.username : null;
 
   // const idempotencyKey = req.headers("Idempotency-Key"); // TODO implement better transactions
@@ -35,9 +35,4 @@ const updateSettingsController = (req, res) => {
     .catch(error => {
       res.status(404).send({ success: false, message: error.message });
     });
-};
-
-module.exports = {
-  getSettingsController,
-  updateSettingsController
-};
+}

--- a/src/webserver/controllers/user/viewHistory.js
+++ b/src/webserver/controllers/user/viewHistory.js
@@ -1,6 +1,7 @@
-const configuration = require("../../../config/configuration").getInstance();
-const Tautulli = require("../../../tautulli/tautulli");
+import configuration from "../../../config/configuration";
+import Tautulli from "../../../tautulli/tautulli";
 
+const configuration = Configuration.getInstance();
 const apiKey = configuration.get("tautulli", "apiKey");
 const ip = configuration.get("tautulli", "ip");
 const port = configuration.get("tautulli", "port");
@@ -101,9 +102,9 @@ function userViewHistoryController(req, res) {
   // const username = user.username;
 }
 
-module.exports = {
+export default {
   watchTimeStatsController,
-  getPlaysByDaysController,
   getPlaysByDayOfWeekController,
+  getPlaysByDaysController,
   userViewHistoryController
 };

--- a/src/webserver/controllers/user/viewHistory.js
+++ b/src/webserver/controllers/user/viewHistory.js
@@ -1,5 +1,5 @@
-import configuration from "../../../config/configuration";
-import Tautulli from "../../../tautulli/tautulli";
+import Tautulli from "../../../tautulli/tautulli.js";
+import Configuration from "../../../config/configuration.js";
 
 const configuration = Configuration.getInstance();
 const apiKey = configuration.get("tautulli", "apiKey");

--- a/src/webserver/middleware/mustBeAdmin.js
+++ b/src/webserver/middleware/mustBeAdmin.js
@@ -1,4 +1,4 @@
-const establishedDatabase = require("../../database/database");
+import establishedDatabase from "../../database/database";
 
 // eslint-disable-next-line consistent-return
 const mustBeAdmin = (req, res, next) => {
@@ -28,4 +28,4 @@ const mustBeAdmin = (req, res, next) => {
     });
 };
 
-module.exports = mustBeAdmin;
+export default mustBeAdmin;

--- a/src/webserver/middleware/mustBeAdmin.js
+++ b/src/webserver/middleware/mustBeAdmin.js
@@ -1,4 +1,4 @@
-import establishedDatabase from "../../database/database";
+import establishedDatabase from "../../database/database.js";
 
 // eslint-disable-next-line consistent-return
 const mustBeAdmin = (req, res, next) => {

--- a/src/webserver/middleware/mustBeAuthenticated.js
+++ b/src/webserver/middleware/mustBeAuthenticated.js
@@ -10,4 +10,4 @@ const mustBeAuthenticated = (req, res, next) => {
   next();
 };
 
-module.exports = mustBeAuthenticated;
+export default mustBeAuthenticated;

--- a/src/webserver/middleware/mustHaveAccountLinkedToPlex.js
+++ b/src/webserver/middleware/mustHaveAccountLinkedToPlex.js
@@ -1,4 +1,4 @@
-import establishedDatabase from "../../database/database";
+import establishedDatabase from "../../database/database.js";
 
 /* eslint-disable consistent-return */
 const mustHaveAccountLinkedToPlex = (req, res, next) => {

--- a/src/webserver/middleware/mustHaveAccountLinkedToPlex.js
+++ b/src/webserver/middleware/mustHaveAccountLinkedToPlex.js
@@ -1,4 +1,4 @@
-const establishedDatabase = require("../../database/database");
+import establishedDatabase from "../../database/database";
 
 /* eslint-disable consistent-return */
 const mustHaveAccountLinkedToPlex = (req, res, next) => {
@@ -33,4 +33,4 @@ const mustHaveAccountLinkedToPlex = (req, res, next) => {
 };
 /* eslint-enable consistent-return */
 
-module.exports = mustHaveAccountLinkedToPlex;
+export default mustHaveAccountLinkedToPlex;

--- a/src/webserver/middleware/reqTokenToUser.js
+++ b/src/webserver/middleware/reqTokenToUser.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
-import Configuration from "../../config/configuration";
-import Token from "../../user/token";
+import Configuration from "../../config/configuration.js";
+import Token from "../../user/token.js";
 
 const configuration = Configuration.getInstance();
 const secret = configuration.get("authentication", "secret");

--- a/src/webserver/middleware/reqTokenToUser.js
+++ b/src/webserver/middleware/reqTokenToUser.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-param-reassign */
-const configuration = require("../../config/configuration").getInstance();
-const Token = require("../../user/token");
+import Configuration from "../../config/configuration";
+import Token from "../../user/token";
 
+const configuration = Configuration.getInstance();
 const secret = configuration.get("authentication", "secret");
 
 // Token example:
@@ -25,4 +26,4 @@ const reqTokenToUser = (req, res, next) => {
   return next();
 };
 
-module.exports = reqTokenToUser;
+export default reqTokenToUser;

--- a/src/webserver/server.js
+++ b/src/webserver/server.js
@@ -1,11 +1,15 @@
-import Configuration from "../config/configuration";
-import app from "./app";
+import Configuration from "../config/configuration.js";
+import app from "./app.js";
 
 const configuration = Configuration.getInstance();
 
-export default app.listen(config.get("webserver", "port"), () => {
+export default app.listen(configuration.get("webserver", "port"), () => {
   /* eslint-disable no-console */
   console.log("seasonedAPI");
-  console.log(`Database is located at ${config.get("database", "host")}`);
-  console.log(`Webserver is listening on ${config.get("webserver", "port")}`);
+  console.log(
+    `Database is located at ${configuration.get("database", "host")}`
+  );
+  console.log(
+    `Webserver is listening on ${configuration.get("webserver", "port")}`
+  );
 });

--- a/src/webserver/server.js
+++ b/src/webserver/server.js
@@ -1,7 +1,9 @@
-const config = require("../config/configuration").getInstance();
-const app = require("./app");
+import Configuration from "../config/configuration";
+import app from "./app";
 
-module.exports = app.listen(config.get("webserver", "port"), () => {
+const configuration = Configuration.getInstance();
+
+export default app.listen(config.get("webserver", "port"), () => {
   /* eslint-disable no-console */
   console.log("seasonedAPI");
   console.log(`Database is located at ${config.get("database", "host")}`);

--- a/tests/helpers/createCacheEntry.js
+++ b/tests/helpers/createCacheEntry.js
@@ -1,7 +1,5 @@
-const redisCache = require("../../src/cache/redis");
+import redisCache from "../../src/cache/redis.js";
 
-function createCacheEntry(key, value) {
+export default function createCacheEntry(key, value) {
   return redisCache.set(key, value);
 }
-
-module.exports = createCacheEntry;

--- a/tests/helpers/createToken.js
+++ b/tests/helpers/createToken.js
@@ -1,10 +1,8 @@
-const User = require("../../src/user/user");
-const Token = require("../../src/user/token");
+import User from "../../src/user/user.js";
+import Token from "../../src/user/token.js";
 
-function createToken(username, secret) {
+export default function createToken(username, secret) {
   const user = new User(username);
   const token = new Token(user);
   return token.toString(secret);
 }
-
-module.exports = createToken;

--- a/tests/helpers/createUser.js
+++ b/tests/helpers/createUser.js
@@ -1,11 +1,9 @@
-const User = require("../../src/user/user");
-const UserSecurity = require("../../src/user/userSecurity");
+import User from "../../src/user/user.js";
+import UserSecurity from "../../src/user/userSecurity.js";
 
-function createUser(username, password) {
+export default function createUser(username, password) {
   const userSecurity = new UserSecurity();
   const user = new User(username);
 
   return userSecurity.createNewUser(user, password);
 }
-
-module.exports = createUser;

--- a/tests/helpers/importFixture.js
+++ b/tests/helpers/importFixture.js
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function determineLocation(fixtureFilename) {
+  return path.join(__dirname, "..", "fixtures", fixtureFilename);
+}
+
+export default function readFixtureContents(fixtureFilename) {
+  const location = determineLocation(fixtureFilename);
+
+  let content = {};
+  try {
+    content = JSON.parse(fs.readFileSync(location, { encoding: "utf-8" }));
+  } catch (err) {
+    console.error(`Error loading fixture file at path: ${location}`);
+  }
+
+  return content;
+}

--- a/tests/helpers/resetDatabase.js
+++ b/tests/helpers/resetDatabase.js
@@ -10,13 +10,11 @@
 //   }
 // }
 
-const establishedDatabase = require("../../src/database/database");
+import establishedDatabase from "../../src/database/database.js";
 // const establishedDatabase = new EstablishedDatabase();
 
-function resetDatabase() {
+export default function resetDatabase() {
   return Promise.resolve()
     .then(() => establishedDatabase.tearDown())
     .then(() => establishedDatabase.setUp());
 }
-
-module.exports = resetDatabase;

--- a/tests/helpers/tmdbMock2.js
+++ b/tests/helpers/tmdbMock2.js
@@ -12,4 +12,4 @@ const tmdbMock = () => ({
   }
 });
 
-module.exports = tmdbMock;
+export default tmdbMock;

--- a/tests/system/asADeveloperIWantTheServerToRegister.js
+++ b/tests/system/asADeveloperIWantTheServerToRegister.js
@@ -1,9 +1,9 @@
-const assert = require("assert");
-const chai = require("chai");
-const chaiHttp = require("chai-http");
+import assert from "assert";
+import chai from "chai";
+import chaiHttp from "chai-http";
 
-const server = require("../../src/webserver/server");
-const resetDatabase = require("../helpers/resetDatabase");
+import server from "../../src/webserver/server.js";
+import resetDatabase from "../helpers/resetDatabase.js";
 
 chai.use(chaiHttp);
 

--- a/tests/system/asADeveloperIWantTheServerToStart.js.disabled
+++ b/tests/system/asADeveloperIWantTheServerToStart.js.disabled
@@ -1,6 +1,6 @@
 /* eslint-disable no-return-assign */
-const net = require("net");
-const server = require("../../src/webserver/server");
+import net from "net";
+import server from "../../src/webserver/server.js";
 
 describe("As a developer I want the server to start", () => {
   after(() => {

--- a/tests/system/asADeveloperIWantToLogin.js
+++ b/tests/system/asADeveloperIWantToLogin.js
@@ -1,10 +1,10 @@
-const assert = require("assert");
-const chai = require("chai");
-const chaiHttp = require("chai-http");
+import assert from "assert";
+import chai from "chai";
+import chaiHttp from "chai-http";
 
-const server = require("../../src/webserver/server");
-const createUser = require("../helpers/createUser");
-const resetDatabase = require("../helpers/resetDatabase");
+import server from "../../src/webserver/server.js";
+import createUser from "../helpers/createUser.js";
+import resetDatabase from "../helpers/resetDatabase.js";
 
 chai.use(chaiHttp);
 

--- a/tests/system/asAUserIWantAForbiddenErrorIfTheTokenIsMalformed.js
+++ b/tests/system/asAUserIWantAForbiddenErrorIfTheTokenIsMalformed.js
@@ -1,9 +1,9 @@
-const assert = require("assert");
-const chai = require("chai");
-const chaiHttp = require("chai-http");
+import assert from "assert";
+import chai from "chai";
+import chaiHttp from "chai-http";
 
-const server = require("../../src/webserver/server");
-const resetDatabase = require("../helpers/resetDatabase");
+import server from "../../src/webserver/server.js";
+import resetDatabase from "../helpers/resetDatabase.js";
 
 chai.use(chaiHttp);
 

--- a/tests/system/asAUserIWantToGetErrorWhenRegisteringExistingUsername.js
+++ b/tests/system/asAUserIWantToGetErrorWhenRegisteringExistingUsername.js
@@ -1,10 +1,10 @@
-const assert = require("assert");
-const chai = require("chai");
-const chaiHttp = require("chai-http");
+import assert from "assert";
+import chai from "chai";
+import chaiHttp from "chai-http";
 
-const server = require("../../src/webserver/server");
-const createUser = require("../helpers/createUser");
-const resetDatabase = require("../helpers/resetDatabase");
+import server from "../../src/webserver/server.js";
+import createUser from "../helpers/createUser.js";
+import resetDatabase from "../helpers/resetDatabase.js";
 
 chai.use(chaiHttp);
 

--- a/tests/system/asAUserIWantToGetPopularMovies.js
+++ b/tests/system/asAUserIWantToGetPopularMovies.js
@@ -5,18 +5,17 @@ import chaiHttp from "chai-http";
 import server from "../../src/webserver/server.js";
 import resetDatabase from "../helpers/resetDatabase.js";
 import createCacheEntry from "../helpers/createCacheEntry.js";
-const popularMoviesSuccess = await import(
-  "../fixtures/popular-movies-success-response.json",
-  {
-    assert: { type: "json" }
-  }
-);
+import readFixtureContents from "../helpers/importFixture.js";
 
 chai.use(chaiHttp);
 
+const popularMoviesSuccess = readFixtureContents(
+  "popular-movies-success-response.json"
+);
+
 describe("As a user I want to get popular movies", () => {
   beforeEach(() => resetDatabase());
-  beforeEach(() => createCacheEntry("tmdb/pm:1", popularMoviesSuccess.default));
+  beforeEach(() => createCacheEntry("tmdb/pm:1", popularMoviesSuccess));
 
   it("should return 200 with the information", done => {
     chai

--- a/tests/system/asAUserIWantToGetPopularMovies.js
+++ b/tests/system/asAUserIWantToGetPopularMovies.js
@@ -1,17 +1,22 @@
-const assert = require("assert");
-const chai = require("chai");
-const chaiHttp = require("chai-http");
+import assert from "assert";
+import chai from "chai";
+import chaiHttp from "chai-http";
 
-const server = require("../../src/webserver/server");
-const resetDatabase = require("../helpers/resetDatabase");
-const createCacheEntry = require("../helpers/createCacheEntry");
-const popularMoviesSuccess = require("../fixtures/popular-movies-success-response.json");
+import server from "../../src/webserver/server.js";
+import resetDatabase from "../helpers/resetDatabase.js";
+import createCacheEntry from "../helpers/createCacheEntry.js";
+const popularMoviesSuccess = await import(
+  "../fixtures/popular-movies-success-response.json",
+  {
+    assert: { type: "json" }
+  }
+);
 
 chai.use(chaiHttp);
 
 describe("As a user I want to get popular movies", () => {
   beforeEach(() => resetDatabase());
-  beforeEach(() => createCacheEntry("tmdb/pm:1", popularMoviesSuccess));
+  beforeEach(() => createCacheEntry("tmdb/pm:1", popularMoviesSuccess.default));
 
   it("should return 200 with the information", done => {
     chai

--- a/tests/system/asAUserIWantToGetPopularShows.js
+++ b/tests/system/asAUserIWantToGetPopularShows.js
@@ -1,17 +1,22 @@
-const assert = require("assert");
-const chai = require("chai");
-const chaiHttp = require("chai-http");
+import assert from "assert";
+import chai from "chai";
+import chaiHttp from "chai-http";
 
-const server = require("../../src/webserver/server");
-const resetDatabase = require("../helpers/resetDatabase");
-const createCacheEntry = require("../helpers/createCacheEntry");
-const popularShowsSuccess = require("../fixtures/popular-show-success-response.json");
+import server from "../../src/webserver/server.js";
+import resetDatabase from "../helpers/resetDatabase.js";
+import createCacheEntry from "../helpers/createCacheEntry.js";
+const popularShowsSuccess = await import(
+  "../fixtures/popular-show-success-response.json",
+  {
+    assert: { type: "json" }
+  }
+);
 
 chai.use(chaiHttp);
 
 describe("As a user I want to get popular shows", () => {
   beforeEach(() => resetDatabase());
-  beforeEach(() => createCacheEntry("tmdb/pt:1", popularShowsSuccess));
+  beforeEach(() => createCacheEntry("tmdb/pt:1", popularShowsSuccess.default));
 
   it("should return 200 with the information", done => {
     chai

--- a/tests/system/asAUserIWantToGetPopularShows.js
+++ b/tests/system/asAUserIWantToGetPopularShows.js
@@ -5,18 +5,17 @@ import chaiHttp from "chai-http";
 import server from "../../src/webserver/server.js";
 import resetDatabase from "../helpers/resetDatabase.js";
 import createCacheEntry from "../helpers/createCacheEntry.js";
-const popularShowsSuccess = await import(
-  "../fixtures/popular-show-success-response.json",
-  {
-    assert: { type: "json" }
-  }
-);
+import readFixtureContents from "../helpers/importFixture.js";
 
 chai.use(chaiHttp);
 
+const popularShowsSuccess = readFixtureContents(
+  "popular-show-success-response.json"
+);
+
 describe("As a user I want to get popular shows", () => {
   beforeEach(() => resetDatabase());
-  beforeEach(() => createCacheEntry("tmdb/pt:1", popularShowsSuccess.default));
+  beforeEach(() => createCacheEntry("tmdb/pt:1", popularShowsSuccess));
 
   it("should return 200 with the information", done => {
     chai

--- a/tests/system/asAUserIWantToRequestAMovie.js
+++ b/tests/system/asAUserIWantToRequestAMovie.js
@@ -1,20 +1,28 @@
-const assert = require("assert");
-const chai = require("chai");
-const chaiHttp = require("chai-http");
+import assert from "assert";
+import chai from "chai";
+import chaiHttp from "chai-http";
 
-const server = require("../../src/webserver/server");
-const createUser = require("../helpers/createUser");
-const createToken = require("../helpers/createToken");
-const resetDatabase = require("../helpers/resetDatabase");
-const createCacheEntry = require("../helpers/createCacheEntry");
-const infoMovieSuccess = require("../fixtures/blade_runner_2049-info-success-response.json");
+import server from "../../src/webserver/server.js";
+import createUser from "../helpers/createUser.js";
+import createToken from "../helpers/createToken.js";
+import resetDatabase from "../helpers/resetDatabase.js";
+import createCacheEntry from "../helpers/createCacheEntry.js";
+
+const infoMovieSuccess = await import(
+  "../fixtures/blade_runner_2049-info-success-response.json",
+  {
+    assert: { type: "json" }
+  }
+);
 
 chai.use(chaiHttp);
 
 describe("As a user I want to request a movie", () => {
   beforeEach(() => resetDatabase());
   beforeEach(() => createUser("test_user", "test@gmail.com", "password"));
-  beforeEach(() => createCacheEntry("mi:335984:false", infoMovieSuccess));
+  beforeEach(() =>
+    createCacheEntry("mi:335984:false", infoMovieSuccess.default)
+  );
 
   it("should return 200 when item is requested", () => {
     chai

--- a/tests/system/asAUserIWantToRequestAMovie.js
+++ b/tests/system/asAUserIWantToRequestAMovie.js
@@ -7,22 +7,18 @@ import createUser from "../helpers/createUser.js";
 import createToken from "../helpers/createToken.js";
 import resetDatabase from "../helpers/resetDatabase.js";
 import createCacheEntry from "../helpers/createCacheEntry.js";
-
-const infoMovieSuccess = await import(
-  "../fixtures/blade_runner_2049-info-success-response.json",
-  {
-    assert: { type: "json" }
-  }
-);
+import readFixtureContents from "../helpers/importFixture.js";
 
 chai.use(chaiHttp);
+
+const infoMovieSuccess = readFixtureContents(
+  "blade_runner_2049-info-success-response.json"
+);
 
 describe("As a user I want to request a movie", () => {
   beforeEach(() => resetDatabase());
   beforeEach(() => createUser("test_user", "test@gmail.com", "password"));
-  beforeEach(() =>
-    createCacheEntry("mi:335984:false", infoMovieSuccess.default)
-  );
+  beforeEach(() => createCacheEntry("mi:335984:false", infoMovieSuccess));
 
   it("should return 200 when item is requested", () => {
     chai

--- a/tests/system/asAnAnonymousUserIWantToSearchForAMovie.js
+++ b/tests/system/asAnAnonymousUserIWantToSearchForAMovie.js
@@ -5,22 +5,18 @@ import chaiHttp from "chai-http";
 import server from "../../src/webserver/server.js";
 import resetDatabase from "../helpers/resetDatabase.js";
 import createCacheEntry from "../helpers/createCacheEntry.js";
-const interstellarQuerySuccess = await import(
-  "../fixtures/interstellar-query-movie-success-response.json",
-  {
-    assert: { type: "json" }
-  }
-);
+import readFixtureContents from "../helpers/importFixture.js";
 
 chai.use(chaiHttp);
+
+const interstellarQuerySuccess = readFixtureContents(
+  "interstellar-query-movie-success-response.json"
+);
 
 describe("As an anonymous user I want to search for a movie", () => {
   beforeEach(() => resetDatabase());
   beforeEach(() =>
-    createCacheEntry(
-      "tmdb/mos:1:interstellar:false",
-      interstellarQuerySuccess.default
-    )
+    createCacheEntry("tmdb/mos:1:interstellar:false", interstellarQuerySuccess)
   );
 
   it("should return 200 with the search results even if user is not logged in", done => {

--- a/tests/system/asAnAnonymousUserIWantToSearchForAMovie.js
+++ b/tests/system/asAnAnonymousUserIWantToSearchForAMovie.js
@@ -1,18 +1,26 @@
-const assert = require("assert");
-const chai = require("chai");
-const chaiHttp = require("chai-http");
+import assert from "assert";
+import chai from "chai";
+import chaiHttp from "chai-http";
 
-const server = require("../../src/webserver/server");
-const resetDatabase = require("../helpers/resetDatabase");
-const createCacheEntry = require("../helpers/createCacheEntry");
-const interstellarQuerySuccess = require("../fixtures/interstellar-query-movie-success-response.json");
+import server from "../../src/webserver/server.js";
+import resetDatabase from "../helpers/resetDatabase.js";
+import createCacheEntry from "../helpers/createCacheEntry.js";
+const interstellarQuerySuccess = await import(
+  "../fixtures/interstellar-query-movie-success-response.json",
+  {
+    assert: { type: "json" }
+  }
+);
 
 chai.use(chaiHttp);
 
 describe("As an anonymous user I want to search for a movie", () => {
   beforeEach(() => resetDatabase());
   beforeEach(() =>
-    createCacheEntry("tmdb/mos:1:interstellar:false", interstellarQuerySuccess)
+    createCacheEntry(
+      "tmdb/mos:1:interstellar:false",
+      interstellarQuerySuccess.default
+    )
   );
 
   it("should return 200 with the search results even if user is not logged in", done => {

--- a/tests/unit/config/testConfig.js
+++ b/tests/unit/config/testConfig.js
@@ -1,78 +1,77 @@
-const assert = require("assert");
-const Config = require("../../../src/config/configuration");
+import assert from "assert";
+import Configuration from "../../../src/config/configuration.js";
+
+const configuration = Configuration.getInstance();
+
+let backedUpEnvironmentVariables;
+let backedUpConfigFields;
 
 describe("Config", () => {
   beforeEach(() => {
-    this.backedUpEnvironmentVariables = { ...process.env };
-    this.backedUpConfigFields = { ...Config.getInstance().fields };
+    backedUpEnvironmentVariables = { ...process.env };
+    backedUpConfigFields = { ...configuration.fields };
   });
 
   afterEach(() => {
-    process.env = this.backedUpEnvironmentVariables;
-    Config.getInstance().fields = this.backedUpConfigFields;
+    process.env = backedUpEnvironmentVariables;
+    configuration.fields = backedUpConfigFields;
   });
 
   it("should retrieve section and option from config file", () => {
-    Config.getInstance().fields = { webserver: { port: 1337 } };
-    assert.equal(Config.getInstance().get("webserver", "port"), 1337);
+    configuration.fields = { webserver: { port: 1337 } };
+    assert.equal(configuration.get("webserver", "port"), 1337);
   });
 
   it("should resolve to environment variables if option is filtered with env", () => {
-    Config.getInstance().fields = {
+    configuration.fields = {
       webserver: { port: "env|SEASONED_WEBSERVER_PORT" }
     };
     process.env.SEASONED_WEBSERVER_PORT = "1338";
-    assert.equal(Config.getInstance().get("webserver", "port"), 1338);
+    assert.equal(configuration.get("webserver", "port"), 1338);
   });
 
   it("raises an exception if the environment variable does not exist", () => {
-    Config.getInstance().fields = { webserver: { port: "env|DOES_NOT_EXIST" } };
+    configuration.fields = { webserver: { port: "env|DOES_NOT_EXIST" } };
     process.env.SEASONED_WEBSERVER_PORT = "1338";
-    assert.throws(() => Config.getInstance().get("webserver", "port"), /empty/);
+    assert.throws(() => configuration.get("webserver", "port"), /empty/);
   });
 
   it("raises an exception if the environment variable is empty", () => {
-    Config.getInstance().fields = {
+    configuration.fields = {
       webserver: { port: "env|SEASONED_WEBSERVER_PORT" }
     };
     process.env.SEASONED_WEBSERVER_PORT = "";
-    assert.throws(() => Config.getInstance().get("webserver", "port"), /empty/);
+    assert.throws(() => configuration.get("webserver", "port"), /empty/);
   });
 
   it("raises an exception if the section does not exist in the file", () => {
-    Config.getInstance().fields = { webserver: { port: "1338" } };
-    assert.throws(
-      () => Config.getInstance().get("woops", "port"),
-      /does not exist/
-    );
+    configuration.fields = { webserver: { port: "1338" } };
+    assert.throws(() => configuration.get("woops", "port"), /does not exist/);
   });
 
   it("raises an exception if the option does not exist in the file", () => {
-    Config.getInstance().fields = { webserver: { port: "1338" } };
+    configuration.fields = { webserver: { port: "1338" } };
     assert.throws(
-      () => Config.getInstance().get("webserver", "woops"),
+      () => configuration.get("webserver", "woops"),
       /does not exist/
     );
   });
 
   it("returns an array if field is an array", () => {
-    Config.getInstance().fields = { bouncer: { whitelist: [1, 2, 3] } };
-    assert.deepEqual(
-      Config.getInstance().get("bouncer", "whitelist"),
-      [1, 2, 3]
-    );
+    configuration.fields = { bouncer: { whitelist: [1, 2, 3] } };
+    assert.deepEqual(configuration.get("bouncer", "whitelist"), [1, 2, 3]);
   });
 
   it("decodes field as base64 if base64| is before the variable", () => {
-    Config.getInstance().fields = { webserver: { port: "base64|MTMzOA==" } };
-    assert.equal(Config.getInstance().get("webserver", "port"), 1338);
+    configuration.fields = { webserver: { port: "base64|MTMzOA==" } };
+    assert.equal(configuration.get("webserver", "port"), 1338);
   });
 
   it("decodes environment variable as base64 if BASE64= is before the variable", () => {
-    Config.getInstance().fields = {
+    configuration.fields = {
       webserver: { port: "env|base64|SEASONED_WEBSERVER_PORT" }
     };
     process.env.SEASONED_WEBSERVER_PORT = "MTMzOA==";
-    assert.equal(Config.getInstance().get("webserver", "port"), 1338);
+    assert.equal(configuration.get("webserver", "port"), 1338);
   });
 });

--- a/tests/unit/config/testField.js
+++ b/tests/unit/config/testField.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const Field = require("../../../src/config/field");
+import assert from "assert";
+import Field from "../../../src/config/field.js";
 
 describe("Field", () => {
   it("should return an array if it is an array", () => {

--- a/tests/unit/config/testFilters.js
+++ b/tests/unit/config/testFilters.js
@@ -1,5 +1,5 @@
-const assert = require("assert");
-const Filters = require("../../../src/config/filters");
+import assert from "assert";
+import Filters from "../../../src/config/filters.js";
 
 describe("Filters", () => {
   it("should extract base64 as filter if it is at start of string followed by pipe", () => {

--- a/tests/unit/tmdb/testConvertTmdbToMovie.js
+++ b/tests/unit/tmdb/testConvertTmdbToMovie.js
@@ -1,18 +1,17 @@
 import assert from "assert";
 // import convertTmdbToMovie = require('src/tmdb/convertTmdbToMovie');
 import { Movie } from "../../../src/tmdb/types.js";
-const bladeRunnerQuerySuccess = await import(
-  "../../fixtures/blade_runner_2049-info-success-response.json",
-  {
-    assert: { type: "json" }
-  }
+import readFixtureContents from "../../helpers/importFixture.js";
+
+const bladeRunnerQuerySuccess = readFixtureContents(
+  "blade_runner_2049-info-success-response.json"
 );
 
 let bladeRunnerTmdbMovie;
 
 describe("Convert tmdb movieInfo to movie", () => {
   beforeEach(() => {
-    bladeRunnerTmdbMovie = bladeRunnerQuerySuccess.default[0];
+    [bladeRunnerTmdbMovie] = bladeRunnerQuerySuccess;
   });
 
   it("should translate the tmdb release date to movie year", () => {

--- a/tests/unit/tmdb/testConvertTmdbToMovie.js
+++ b/tests/unit/tmdb/testConvertTmdbToMovie.js
@@ -1,38 +1,37 @@
-const assert = require("assert");
-// const convertTmdbToMovie = require('src/tmdb/convertTmdbToMovie');
-const { Movie } = require("../../../src/tmdb/types");
-const bladeRunnerQuerySuccess = require("../../fixtures/blade_runner_2049-info-success-response.json");
+import assert from "assert";
+// import convertTmdbToMovie = require('src/tmdb/convertTmdbToMovie');
+import { Movie } from "../../../src/tmdb/types.js";
+const bladeRunnerQuerySuccess = await import(
+  "../../fixtures/blade_runner_2049-info-success-response.json",
+  {
+    assert: { type: "json" }
+  }
+);
+
+let bladeRunnerTmdbMovie;
 
 describe("Convert tmdb movieInfo to movie", () => {
   beforeEach(() => {
-    [this.bladeRunnerTmdbMovie] = bladeRunnerQuerySuccess;
+    bladeRunnerTmdbMovie = bladeRunnerQuerySuccess.default[0];
   });
 
   it("should translate the tmdb release date to movie year", () => {
-    const bladeRunner = Movie.convertFromTmdbResponse(
-      this.bladeRunnerTmdbMovie
-    );
+    const bladeRunner = Movie.convertFromTmdbResponse(bladeRunnerTmdbMovie);
     assert.strictEqual(bladeRunner.year, 2017);
   });
 
   it("should translate the tmdb release date to instance of Date", () => {
-    const bladeRunner = Movie.convertFromTmdbResponse(
-      this.bladeRunnerTmdbMovie
-    );
+    const bladeRunner = Movie.convertFromTmdbResponse(bladeRunnerTmdbMovie);
     assert(bladeRunner.releaseDate instanceof Date);
   });
 
   it("should translate the tmdb title to title", () => {
-    const bladeRunner = Movie.convertFromTmdbResponse(
-      this.bladeRunnerTmdbMovie
-    );
+    const bladeRunner = Movie.convertFromTmdbResponse(bladeRunnerTmdbMovie);
     assert.equal(bladeRunner.title, "Blade Runner 2049");
   });
 
   it("should translate the tmdb vote_average to rating", () => {
-    const bladeRunner = Movie.convertFromTmdbResponse(
-      this.bladeRunnerTmdbMovie
-    );
+    const bladeRunner = Movie.convertFromTmdbResponse(bladeRunnerTmdbMovie);
     assert.equal(bladeRunner.rating, 7.3);
   });
 });

--- a/tests/unit/tmdb/testTmdb.disabled
+++ b/tests/unit/tmdb/testTmdb.disabled
@@ -1,13 +1,13 @@
-const assert = require('assert');
-// const Movie = require('src/movie/movie');
-const TMDB = require('src/tmdb/tmdb');
-const Cache = require('src/tmdb/cache');
-const SqliteDatabase = require('src/database/sqliteDatabase');
-const tmdbMock = require('test/helpers/tmdbMock');
+import assert 'assert';
+// import require('src/movie/movie.js';
+import TMDB 'src/tmdb/tmdb.js';
+import Cache 'src/tmdb/cache.js';
+import SqliteDatabase 'src/database/sqliteDatabase.js';
+import tmdbMock 'test/helpers/tmdbMock.js';
 
-const emptyQuerySuccess = require('tests/fixtures/empty-query-success-response.json');
-const interstellarQuerySuccess = require('tests/fixtures/arrival-info-success-response.json');
-const popularMovieSuccessResponse = require('tests/fixtures/popular-movies-success-response.json');
+import emptyQuerySuccess 'tests/fixtures/empty-query-success-response.json';
+import interstellarQuerySuccess 'tests/fixture/arrival-info-success-response.json');
+import popularMovieSuccessResponse 'tests/fixture/popular-movies-success-response.json');
 
 describe('TMDB', function test() {
   beforeEach(() => {


### PR DESCRIPTION
Converted all files from commonjs to es modules, mostly involves: 
 - Change from using `require` to `import` for loading modules.
 - Splitting `const configuration = require("../config/configuration").getInstance()` into separate import and function call steps.
 - Use `import.meta.url` to define `__dirname`.
 - Replace all `module.exports` with `export default`.